### PR TITLE
Add GitHub Action for automating release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+on:
+  push:
+    tags:
+      - "v*" # push events to matching v*, i.e. v1.0, v20.15.10
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl"]
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --target ${{ matrix.target }}
+      - uses: actions/upload-artifact@v1.0.0
+        with:
+          name: "zoxide-${{ matrix.target }}"
+          path: "target/${{ matrix.target }}/release/zoxide"
+
+  build-darwin:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target x86_64-apple-darwin
+      - uses: actions/upload-artifact@v1.0.0
+        with:
+          name: "zoxide-x86_64-apple-darwin"
+          path: "target/x86_64-apple-darwin/release/zoxide"
+
+  release-upload:
+    needs:
+      - build-linux
+      - build-darwin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - id: create_release
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+
+      - uses: actions/download-artifact@v1
+        with:
+          name: "zoxide-x86_64-unknown-linux-gnu"
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: "zoxide-x86_64-unknown-linux-gnu/zoxide"
+          asset_name: "zoxide-x86_64-unknown-linux-gnu"
+          asset_content_type: application/octet-stream
+
+      - uses: actions/download-artifact@v1
+        with:
+          name: "zoxide-x86_64-unknown-linux-musl"
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: "zoxide-x86_64-unknown-linux-musl/zoxide"
+          asset_name: "zoxide-x86_64-unknown-linux-musl"
+          asset_content_type: application/octet-stream
+
+      - uses: actions/download-artifact@v1
+        with:
+          name: "zoxide-x86_64-apple-darwin"
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: "zoxide-x86_64-apple-darwin/zoxide"
+          asset_name: "zoxide-x86_64-apple-darwin"
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
This PR adds a GitHub Action to create and upload releases to GitHub. It currently supports the following targets:

- `x86_64-unknown-linux-gnu`
- `x86_64-unknown-linux-musl`
- `x86_64-apple-darwin`