### PR TITLE
fix(zsh): append `_zoxide_precmd` as a single-element array to hook

### DIFF
--- a/zoxide.plugin.zsh
+++ b/zoxide.plugin.zsh
@@ -5,7 +5,7 @@ _zoxide_precmd() {
 }
 
 [[ -n "${precmd_functions[(r)_zoxide_precmd]}" ]] || {
-    precmd_functions+=_zoxide_precmd
+    precmd_functions+=(_zoxide_precmd)
 }
 
 z() {


### PR DESCRIPTION
We should append `_zoxide_precmd` to `precmd_functions` within an array literal, not by itself.

This is important because...well, otherwise `precmd_functions` doesn't remain an array. One can only get an array assigned into the left-hand symbol by appending *another* array, because...well, that's what's expected in `zsh` and `bash`! Is it weird? Yes. But that's the type system we live with!