### PR TITLE
added ohmyzsh section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ Using [antibody](https://github.com/getantibody/antibody):
 antibody bundle ajeetdsouza/zoxide
 ```
 
+Using [ohmyzsh](https://github.com/ohmyzsh/ohmyzsh)
+
+```sh
+mkdir -p $HOME/.oh-my-zsh/custom/plugins/zoxide && curl https://github.com/ajeetdsouza/zoxide/raw/master/zoxide.plugin.zsh -o $HOME/.oh-my-zsh/custom/plugins/zoxide/zoxide.plugin.zsh
+```
+
+Then add `zoxide` to the plugins section in your `.zshrc`
+
 Using [zinit](https://github.com/zdharma/zinit):
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ antibody bundle ajeetdsouza/zoxide
 Using [ohmyzsh](https://github.com/ohmyzsh/ohmyzsh)
 
 ```sh
-mkdir -p $HOME/.oh-my-zsh/custom/plugins/zoxide && curl https://github.com/ajeetdsouza/zoxide/raw/master/zoxide.plugin.zsh -o $HOME/.oh-my-zsh/custom/plugins/zoxide/zoxide.plugin.zsh
+mkdir -p $HOME/.oh-my-zsh/custom/plugins/zoxide && curl https://raw.githubusercontent.com/ajeetdsouza/zoxide/master/zoxide.plugin.zsh -o $HOME/.oh-my-zsh/custom/plugins/zoxide/zoxide.plugin.zsh
 ```
 
 Then add `zoxide` to the plugins section in your `.zshrc`


### PR DESCRIPTION
Basic shell command to add zoxide via ohmyzsh plugin manager

Tested and working with ohmyzsh on my  ubuntu machine after installing zoxide with cargo

The command may be able to be made shorter or more portable.