### PR TITLE
Make z more plugin compatible with cd

### DIFF
--- a/functions/z.fish
+++ b/functions/z.fish
@@ -1,7 +1,9 @@
 function z
-  if test (count $argv) -gt 0
-    if test "$argv[1]" = "-"
+  set -l argc (count $argv)
+  if test $argc -gt 0
+    if test $argc -eq 1 -a "$argv[1]" = "-"
       cd -
+      commandline -f repaint
     else
       set _Z_RESULT (zoxide query $argv)
       switch "$_Z_RESULT"
@@ -14,5 +16,7 @@ function z
     end
   else
     cd ~
+    commandline -f repaint
   end
 end
+

--- a/functions/z.fish
+++ b/functions/z.fish
@@ -1,13 +1,18 @@
 function z
-    if test (count $argv) -gt 0
-        set _Z_RESULT (zoxide query $argv)
-        switch "$_Z_RESULT"
-            case 'query: *'
-                cd (string sub -s 8 -- "$_Z_RESULT")
-                commandline -f repaint
-            case '*'
-                echo -n "$_Z_RESULT"
-        end
+  if test (count $argv) -gt 0
+    if test "$argv[1]" = "-"
+      cd -
+    else
+      set _Z_RESULT (zoxide query $argv)
+      switch "$_Z_RESULT"
+        case 'query: *'
+          cd (string sub -s 8 -- "$_Z_RESULT")
+          commandline -f repaint
+        case '*'
+          echo -n "$_Z_RESULT"
+      end
     end
+  else
+    cd ~
+  end
 end
-


### PR DESCRIPTION
Updated `z` uses the following heuristics:

1. Called with no args: `cd ~`
2. Called with `-` as argument: go to previous directory: `cd -`
3. Do the usual `zoxide` stuff
