### PR TITLE
add bash support; installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A cd command that learns your habits
   - [Adding `zoxide` to your shell](#adding-zoxide-to-your-shell)
     - [zsh](#zsh)
     - [fish](#fish)
+    - [bash](#bash)
 - [Configuration](#configuration)
   - [Environment variables](#environment-variables)
 
@@ -105,6 +106,34 @@ Using [oh-my-fish](https://github.com/oh-my-fish/oh-my-fish):
 ```sh
 omf install https://github.com/ajeetdsouza/zoxide
 ```
+
+#### bash
+
+`bash` lacks `zsh` like `precmd` and `preexec` hooks,
+install this little script to help fix that:
+
+```sh
+$ curl https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh -o ~/.bash-preexec.sh
+
+# Add this line to the end of your .bashrc
+source ~/.bash-preexec.sh
+```
+
+Once `precmd` hooks are setup:
+
+```sh
+$ curl https://raw.githubusercontent.com/ajeetdsouza/zoxide/master/bash_zoxide.sh -o ~/.bash_zoxide.sh
+
+# Add this line to the end of your .bashrc
+source ~/.bash_zoxide.sh
+```
+
+Remember to reload `bash`!
+
+```sh
+$ exec bash
+```
+
 
 ## Configuration
 

--- a/bash_zoxide.sh
+++ b/bash_zoxide.sh
@@ -1,0 +1,26 @@
+# pre-command hook
+_zoxide_precmd() {
+    zoxide add
+}
+
+# TODO: find a fool proof way to check for the bash-preexec plugin
+[[ -f ~/.bash_zoxide.sh ]] && precmd_functions+=(_zoxide_precmd)
+
+function z() {
+    if [ $# -ne 0 ]; then
+        _Z_RESULT=$(zoxide query "$@")
+        case $_Z_RESULT in
+            "query: "*)
+                cd "${_Z_RESULT:7}"
+                ;;
+            *)
+                echo "${_Z_RESULT}"
+                ;;
+        esac
+    fi
+}
+
+alias zi="z -i"
+alias za="zoxide add"
+alias zq="zoxide query"
+alias zr="zoxide remove"


### PR DESCRIPTION
- requires installation of the [`bash-preexec`](https://github.com/rcaloras/bash-preexec) script
- no support for any bash plugin managers (i have no experience with any of them)

i hope this pr aligns with the vision of this project, i am willing to make changes as you see fit. thank you for your work on `zoxide`!