### PR TITLE
Migrate from `z` database

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -113,8 +113,8 @@ impl DB {
                     // pass `PathBuf::from(path_str)`
                     self.dirs.push(Dir {
                         path: path.display().to_string(),
-                        last_accessed: epoch,
                         rank,
+                        last_accessed: epoch,
                     });
                 }
                 [] | [""] => {} // ignore blank lines

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,9 +99,7 @@ pub fn main() -> Result<()> {
         }
         Zoxide::Migrate { path } => {
             let mut db = get_db()?;
-
             db.migrate(path)?;
-            db.save()?;
         }
         Zoxide::Init {
             shell,

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,9 @@ enum Zoxide {
     #[structopt(about = "Add a new directory or increment its rank")]
     Add { path: Option<String> },
 
+    #[structopt(about = "Migrate from z database")]
+    Migrate { path: String },
+
     #[structopt(about = "Prints shell configuration")]
     Init {
         #[structopt(possible_values = &Shell::variants(), case_insensitive = true)]
@@ -93,6 +96,12 @@ pub fn main() -> Result<()> {
                     db.add(current_dir, now)
                 }
             }?;
+        }
+        Zoxide::Migrate { path } => {
+            let mut db = get_db()?;
+
+            db.migrate(path)?;
+            db.save()?;
         }
         Zoxide::Init {
             shell,
@@ -208,6 +217,7 @@ end
 
 const INIT_FISH_ALIAS: &str = r#"
 abbr -a zi 'z -i'
+
 abbr -a za 'zoxide add'
 abbr -a zq 'zoxide query'
 abbr -a zr 'zoxide remove'


### PR DESCRIPTION
The new `migrate` function takes in a path to the old `z` database and
naively parses it to add to the database. It sets the epoch to be the
current time in order to prevent scaling down old directories from the
`z` database -- at least until `zoxide` is up and running.

The program will fail if the user already has a database, so as to
prevent tainting it in any way. It will also fail if the database is not
in the expected format -- e.g. if it doesn't follow the
`/path/to/somewhere|1.0101|10101010101` schema. The way this is
validated is by looking for 2 pipe characters and erroring if there is
only 1 (`first_pipe == last_pipe`). It will ignore any dead paths if the
user has not cleaned their database recently.

---

Fix #11 

Do note that, in its current implementation, only a database with `/path/to/somewhere|1.0101|10101010101` format is supported. If there are any other formats, those could be added down the line, as needed.