### PR TITLE
Allow merging when migrating from `z`

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -70,11 +70,11 @@ impl DB {
         Ok(())
     }
 
-    pub fn migrate<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
-        if !self.dirs.is_empty() {
+    pub fn migrate<P: AsRef<Path>>(&mut self, path: P, merge: bool) -> Result<()> {
+        if !self.dirs.is_empty() && !merge {
             bail!(
-                "To prevent conflicts, you can only migrate from z with an empty \
-                 zoxide database!"
+                "To prevent conflicts, you can only migrate from z with an empty zoxide database!
+If you wish to merge the two, specify the `--merge` flag."
             );
         }
 
@@ -130,6 +130,17 @@ impl DB {
                             continue;
                         }
                     };
+
+                    if merge {
+                        // If the path exists in the database, add the ranks and set the epoch to
+                        // the largest of the parsed epoch and the already present epoch.
+                        if let Some(dir) = self.dirs.iter_mut().find(|dir| dir.path == path_str) {
+                            dir.rank += rank;
+                            dir.last_accessed = Epoch::max(epoch, dir.last_accessed);
+
+                            continue;
+                        };
+                    }
 
                     // FIXME: When we switch to PathBuf for storing directories inside Dir, just
                     // pass `PathBuf::from(path_str)`

--- a/src/db.rs
+++ b/src/db.rs
@@ -87,7 +87,10 @@ If you wish to merge the two, specify the `--merge` flag."
             let line = if let Ok(line) = read_line {
                 line
             } else {
-                eprintln!("could not read line {}: {:?}", line_number, read_line);
+                eprintln!(
+                    "could not read entry at line {}: {:?}",
+                    line_number, read_line
+                );
                 continue;
             };
 

--- a/src/subcommand/migrate.rs
+++ b/src/subcommand/migrate.rs
@@ -7,10 +7,13 @@ use structopt::StructOpt;
 #[structopt(about = "Migrate from z database")]
 pub struct Migrate {
     path: String,
+
+    #[structopt(long, help = "Merge entries into existing database")]
+    merge: bool,
 }
 
 impl Migrate {
     pub fn run(&self, env: &Env) -> Result<()> {
-        util::get_db(env)?.migrate(&self.path)
+        util::get_db(env)?.migrate(&self.path, self.merge)
     }
 }


### PR DESCRIPTION
If the user passes the `--merge` flag to the `migrate` subcommand, all
duplicate entries will have their ranks and epochs updated: the rank
will be the sum of the stored rank and the newly-parsed rank, while the
epoch will be the maximum of stored epoch and the newly-parsed epoch.

This allows one to import from the `z` database even after having used
zoxide for any amount of time. This also permits a user who has already
sourced the init script to import their old database without needing to
do something like `rm ~/.zo && zoxide migrate ~/.z`.

---

Inspired by https://github.com/ajeetdsouza/zoxide/issues/11#issuecomment-598916309.

One decision that needs to be made is: do we want to truncate the existing database, or just remove any conflicting paths before re-adding them with the migrated data? I opted for the latter at this time (less destructive seems nice), but I can see an argument for either way.

Thoughs, @ajeetdsouza?