### PR TITLE
Add POSIX shell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A cd command that learns your habits
     - [zsh](#zsh)
     - [bash](#bash)
     - [fish](#fish)
+    - [POSIX](#posix)
 - [Configuration](#configuration)
   - [`init` flags](#init-flags)
   - [Environment variables](#environment-variables)
@@ -88,6 +89,20 @@ Add the following line to your `~/.config/fish/config.fish`:
 ```sh
 zoxide init fish | source
 ```
+
+#### POSIX
+
+Add the following line to your shell's configuration file (or, run it manually):
+
+``` sh
+eval "$(zoxide init posix)"
+```
+
+NOTE: If you modify your `PS1` at any point, you may need to re-run the above command. This is due
+to the fact that we store our hook in `PS1`, in order to be evaluated every time the prompt is
+displayed.
+
+NOTE: There is no PWD hook provided for POSIX shells.
 
 ## Configuration
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ pub fn main() -> Result<()> {
 
     match opt {
         Zoxide::Add(add) => add.run(&env)?,
-        Zoxide::Init(init) => init.run(),
+        Zoxide::Init(init) => init.run()?,
         Zoxide::Migrate(migrate) => migrate.run(&env)?,
         Zoxide::Query(query) => query.run(&env)?,
         Zoxide::Remove(remove) => remove.run(&env)?,

--- a/src/subcommand/init.rs
+++ b/src/subcommand/init.rs
@@ -38,21 +38,20 @@ impl Init {
         let stdout = io::stdout();
         let mut handle = stdout.lock();
 
-        writeln!(handle, "{}", config.z)?;
+        // If any `writeln!` call fails to write to stdout, we assume the user's
+        // computer is on fire and panic.
+        writeln!(handle, "{}", config.z).unwrap();
         if !self.no_define_aliases {
-            writeln!(handle, "{}", config.alias)?;
+            writeln!(handle, "{}", config.alias).unwrap();
         }
 
         match self.hook {
             Hook::none => (),
-            Hook::prompt => writeln!(handle, "{}", config.hook.prompt)?,
-            Hook::pwd => {
-                if let Some(pwd_hook) = config.hook.pwd {
-                    writeln!(handle, "{}", pwd_hook)?;
-                } else {
-                    bail!("PWD hooks are currently unsupported on this shell.");
-                }
-            }
+            Hook::prompt => writeln!(handle, "{}", config.hook.prompt).unwrap(),
+            Hook::pwd => match config.hook.pwd {
+                Some(pwd_hook) => writeln!(handle, "{}", pwd_hook).unwrap(),
+                None => bail!("PWD hooks are currently unsupported on this shell."),
+            },
         }
 
         Ok(())

--- a/src/subcommand/init.rs
+++ b/src/subcommand/init.rs
@@ -1,6 +1,8 @@
+use anyhow::{bail, Result};
 use clap::arg_enum;
-use std::io::{self, Write};
 use structopt::StructOpt;
+
+use std::io::{self, Write};
 
 #[derive(Debug, StructOpt)]
 #[structopt(about = "Generates shell configuration")]
@@ -25,7 +27,7 @@ pub struct Init {
 }
 
 impl Init {
-    pub fn run(&self) {
+    pub fn run(&self) -> Result<()> {
         let config = match self.shell {
             Shell::bash => BASH_CONFIG,
             Shell::fish => FISH_CONFIG,
@@ -36,20 +38,24 @@ impl Init {
         let stdout = io::stdout();
         let mut handle = stdout.lock();
 
-        writeln!(handle, "{}", config.z).unwrap();
+        writeln!(handle, "{}", config.z)?;
         if !self.no_define_aliases {
-            writeln!(handle, "{}", config.alias).unwrap();
+            writeln!(handle, "{}", config.alias)?;
         }
 
         match self.hook {
             Hook::none => (),
-            Hook::prompt => writeln!(handle, "{}", config.hook.prompt).unwrap(),
+            Hook::prompt => writeln!(handle, "{}", config.hook.prompt)?,
             Hook::pwd => {
                 if let Some(pwd_hook) = config.hook.pwd {
-                    writeln!(handle, "{}", pwd_hook).unwrap();
+                    writeln!(handle, "{}", pwd_hook)?;
+                } else {
+                    bail!("PWD hooks are currently unsupported on this shell.");
                 }
             }
-        };
+        }
+
+        Ok(())
     }
 }
 

--- a/src/subcommand/init.rs
+++ b/src/subcommand/init.rs
@@ -243,7 +243,7 @@ end
 
 const POSIX_HOOK_PROMPT: &str = r#"
 _zoxide_hook() {
-    zoxide add
+    zoxide add > /dev/null
 }
 
 case "$PS1" in


### PR DESCRIPTION
Any users of a shell that adheres to the POSIX standard should now be
supported. Shells that were tested while this feature was in development
include `mrsh`, `dash`, busybox `ash`, and `bash --posix`.

The hooks work by defining a `_zoxide_hook` function and adding it to
the shell's `PS1` (causing it to be evaluated every time the prompt is
redrawn).

The PWD hook uses a hack to get it to work properly. Variables are not
available outside of the functions defining them (even if `export`ed),
so we write the current PWD to a temporary file, `/tmp/.zo_pwd`. This is
not ideal, but I cannot think of a better solution apart from removing
the hook entirely.

---

Fix #42 