### PR TITLE
Rework database fallback for v0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,12 @@ zoxide init fish | source
 
 ### Environment variables
 
-- `$_ZO_DATA`: sets the location of the database (default: `~/.zo`)
+- `$_ZO_DATA_DIR`: directory where `zoxide` will store its data files (default:
+    platform-specific; see the [`dirs` documentation] for more information)
 - `$_ZO_ECHO`: `z` will print the matched directory before navigating to it
 - `$_ZO_EXCLUDE_DIRS`: list of directories separated by platform-specific
     characters (`:` on Linux and macOS, and `;` on Windows) to be excluded from
     the database
 - `$_ZO_MAXAGE`: sets the maximum total rank after which entries start getting deleted
+
+[`dirs` documentation]: https://docs.rs/dirs/latest/dirs/fn.data_local_dir.html

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,27 +8,26 @@ use std::fs;
 use std::path::PathBuf;
 
 pub const DB_MAX_SIZE: u64 = 8 * 1024 * 1024; // 8 MiB
-
 pub const DB_VERSION: DBVersion = 3;
 
-pub fn zo_data() -> Result<PathBuf> {
-    let path = match env::var_os("_ZO_DATA") {
+pub fn zo_data_dir() -> Result<PathBuf> {
+    let data_dir = match env::var_os("_ZO_DATA_DIR") {
         Some(data_osstr) => PathBuf::from(data_osstr),
         None => {
-            if let Some(mut cache_dir) = dirs::cache_dir() {
-                cache_dir.push("zoxide");
-                cache_dir
-            } else if let Some(mut home_dir) = dirs::home_dir() {
-                home_dir.push(".zoxide");
-                home_dir
+            if let Some(mut data_dir) = dirs::data_local_dir() {
+                data_dir.push("zoxide");
+                data_dir
             } else {
-                bail!("could not generate default directory, please set _ZO_DATA manually");
+                bail!("could not find database directory, please set _ZO_DATA_DIR manually");
             }
         }
     };
 
-    fs::create_dir_all(&path).context("could not create _ZO_DATA directory")?;
-    Ok(path)
+    // This will fail when `data_dir` points to a file or a broken symlink, but
+    // will no-op on a valid symlink (to a directory), or an actual directory.
+    fs::create_dir_all(&data_dir).context("could not create data directory")?;
+
+    Ok(data_dir)
 }
 
 pub fn zo_exclude_dirs() -> Vec<PathBuf> {
@@ -45,6 +44,7 @@ pub fn zo_maxage() -> Result<Rank> {
                 let maxage = maxage_str
                     .parse::<i64>()
                     .context("unable to parse _ZO_MAXAGE as integer")?;
+
                 Ok(maxage as Rank)
             }
             None => bail!("invalid Unicode in _ZO_MAXAGE"),

--- a/src/db.rs
+++ b/src/db.rs
@@ -48,7 +48,7 @@ impl DB {
         })
     }
 
-    pub fn open_old<P1, P2>(path_old: P1, path: P2) -> Result<DB>
+    pub fn open_and_migrate<P1, P2>(path_old: P1, path: P2) -> Result<DB>
     where
         P1: AsRef<Path>,
         P2: AsRef<Path>,

--- a/src/util.rs
+++ b/src/util.rs
@@ -22,19 +22,21 @@ pub fn path_to_bytes<P: AsRef<Path>>(path: &P) -> Option<&[u8]> {
 }
 
 pub fn get_db() -> Result<DB> {
-    let mut db_file = config::zo_data_dir()?;
-    db_file.push("db.zo");
+    let mut db_path = config::zo_data_dir()?;
+    db_path.push("db.zo");
 
     // FIXME: fallback to old database location; remove in next breaking version
-    if let Some(mut old_db) = dirs::home_dir() {
-        old_db.push(".zo");
+    if !db_path.is_file() {
+        if let Some(mut old_db_path) = dirs::home_dir() {
+            old_db_path.push(".zo");
 
-        if old_db.is_file() && !db_file.is_file() {
-            return DB::open_and_migrate(old_db, db_file);
+            if old_db_path.is_file() {
+                return DB::open_and_migrate(old_db_path, db_path);
+            }
         }
     }
 
-    DB::open(db_file)
+    DB::open(db_path)
 }
 
 pub fn get_current_time() -> Result<Epoch> {


### PR DESCRIPTION
Motivation behind this change is that the old version would only ever use the database at the data home, unless the data home folder (`$HOME/.local/share`) did not exist. This implementation checks for the existence of the old database at `$HOME/.zo`and migrates it to the new storage location; otherwise, it uses `$XDG_DATA_HOME/zoxide` (and creates it if it doesn't exist).