### PR TITLE
Implement _ZO_EXCLUDE_DIRS for v0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ zoxide init fish | source
 
 ### Environment variables
 
-- `$_ZO_ECHO`: `z` will print the matched directory before navigating to it
 - `$_ZO_DATA`: sets the location of the database (default: `~/.zo`)
+- `$_ZO_ECHO`: `z` will print the matched directory before navigating to it
+- `$_ZO_EXCLUDE_DIRS`: list of directories separated by platform-specific
+    characters (`:` on Linux and macOS, and `;` on Windows) to be excluded from
+    the database
 - `$_ZO_MAXAGE`: sets the maximum total rank after which entries start getting deleted

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use crate::types::Rank;
 
 use anyhow::{bail, Context, Result};
+
 use std::env;
 use std::fs;
 use std::path::PathBuf;
@@ -23,6 +24,13 @@ pub fn zo_data() -> Result<PathBuf> {
 
     fs::create_dir_all(&path).context("could not create _ZO_DATA directory")?;
     Ok(path)
+}
+
+pub fn zo_exclude_dirs() -> Vec<PathBuf> {
+    match env::var_os("_ZO_EXCLUDE_DIRS") {
+        Some(dirs_osstr) => env::split_paths(&dirs_osstr).collect(),
+        None => Vec::new(),
+    }
 }
 
 pub fn zo_maxage() -> Result<Rank> {

--- a/src/subcommand/add.rs
+++ b/src/subcommand/add.rs
@@ -2,13 +2,15 @@ use crate::config;
 use crate::util;
 
 use anyhow::{Context, Result};
-use std::env;
 use structopt::StructOpt;
+
+use std::env;
+use std::path::PathBuf;
 
 #[derive(Debug, StructOpt)]
 #[structopt(about = "Add a new directory or increment its rank")]
 pub struct Add {
-    path: Option<String>,
+    path: Option<PathBuf>,
 }
 
 impl Add {
@@ -16,14 +18,17 @@ impl Add {
         let mut db = util::get_db()?;
         let now = util::get_current_time()?;
         let maxage = config::zo_maxage()?;
+        let excluded_dirs = config::zo_exclude_dirs();
 
-        match &self.path {
-            Some(path) => db.add(path, maxage, now),
-            None => {
-                let current_dir =
-                    env::current_dir().context("unable to fetch current directory")?;
-                db.add(current_dir, maxage, now)
-            }
+        let path = match &self.path {
+            Some(path) => path.clone(),
+            None => env::current_dir().context("unable to fetch current directory")?,
+        };
+
+        if excluded_dirs.contains(&path) {
+            return Ok(());
         }
+
+        db.add(path, maxage, now)
     }
 }


### PR DESCRIPTION
_ZO_EXCLUDE_DIRS is a list of paths (separated by colons, `:`, on
Unix-based systems, and semicolons, `;`, on Windows) that should be
excluded from the database. Example:

    _ZO_EXCLUDE_DIRS="$HOME:$HOME/something/super/secret:$HOME/caused/by/background/cds"

---

Closes https://github.com/ajeetdsouza/zoxide/issues/44.