### PR TITLE
Show commit hash in version when built from source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Commit hash to version output.
+- Version output displays `git` revision information.
 
 ## [0.3.0] - 2020-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Commit hash to version output.
+
 ## [0.3.0] - 2020-03-30
 
 ### Added

--- a/build.rs
+++ b/build.rs
@@ -1,14 +1,35 @@
+use std::process::Command;
+
 fn main() {
-    let mut hash = std::process::Command::new("git")
-        .args(&["rev-parse", "--short", "HEAD"])
-        .output()
+    let status_code = Command::new("git")
+        .args(&["describe", "--tags", "--exact-match", "--dirty"])
+        .status()
         .ok()
-        .and_then(|proc| String::from_utf8(proc.stdout).ok())
-        .unwrap_or_default();
+        .and_then(|status| status.code());
 
-    if !hash.is_empty() {
-        hash = format!("-{}", hash);
-    }
+    let is_tagged = match status_code {
+        Some(code) => code == 0,
+        None => false,
+    };
 
-    println!("cargo:rustc-env=GIT_HASH={}", hash);
+    // If this is a tagged commit (a release), we don't want to include the
+    // commit hash in the version output.
+    let revision = if is_tagged {
+        String::new()
+    } else {
+        let mut hash = Command::new("git")
+            .args(&["rev-parse", "--short", "HEAD"])
+            .output()
+            .ok()
+            .and_then(|proc| String::from_utf8(proc.stdout).ok())
+            .unwrap_or_default();
+
+        if !hash.is_empty() {
+            hash = format!("-{}", hash);
+        }
+
+        hash
+    };
+
+    println!("cargo:rustc-env=GIT_HASH={}", revision);
 }

--- a/build.rs
+++ b/build.rs
@@ -5,13 +5,10 @@ fn main() {
         .ok()
         .and_then(|proc| String::from_utf8(proc.stdout).ok());
 
-    let mut version_info = format!("v{}-unknown", env!("CARGO_PKG_VERSION"));
-
-    if let Some(description) = git_describe {
-        if !description.is_empty() {
-            version_info = description;
-        }
-    }
+    let version_info = match git_describe {
+        Some(description) if !description.is_empty() => description,
+        _ => format!("v{}-unknown", env!("CARGO_PKG_VERSION")),
+    };
 
     println!("cargo:rustc-env=ZOXIDE_VERSION={}", version_info);
 }

--- a/build.rs
+++ b/build.rs
@@ -1,35 +1,17 @@
-use std::process::Command;
-
 fn main() {
-    let status_code = Command::new("git")
-        .args(&["describe", "--tags", "--exact-match", "--dirty"])
-        .status()
+    let git_describe = std::process::Command::new("git")
+        .args(&["describe", "--tags", "--broken"])
+        .output()
         .ok()
-        .and_then(|status| status.code());
+        .and_then(|proc| String::from_utf8(proc.stdout).ok());
 
-    let is_tagged = match status_code {
-        Some(code) => code == 0,
-        None => false,
-    };
+    let mut version_info = format!("v{}-unknown", env!("CARGO_PKG_VERSION"));
 
-    // If this is a tagged commit (a release), we don't want to include the
-    // commit hash in the version output.
-    let revision = if is_tagged {
-        String::new()
-    } else {
-        let mut hash = Command::new("git")
-            .args(&["rev-parse", "--short", "HEAD"])
-            .output()
-            .ok()
-            .and_then(|proc| String::from_utf8(proc.stdout).ok())
-            .unwrap_or_default();
-
-        if !hash.is_empty() {
-            hash = format!("-{}", hash);
+    if let Some(description) = git_describe {
+        if !description.is_empty() {
+            version_info = description;
         }
+    }
 
-        hash
-    };
-
-    println!("cargo:rustc-env=GIT_HASH={}", revision);
+    println!("cargo:rustc-env=ZOXIDE_VERSION={}", version_info);
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,14 @@
+fn main() {
+    let mut hash = std::process::Command::new("git")
+        .args(&["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|proc| String::from_utf8(proc.stdout).ok())
+        .unwrap_or_default();
+
+    if !hash.is_empty() {
+        hash = format!("-{}", hash);
+    }
+
+    println!("cargo:rustc-env=GIT_HASH={}", hash);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,10 +8,7 @@ use anyhow::Result;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
-#[structopt(
-    about = "A cd command that learns your habits",
-    version = concat!(env!("CARGO_PKG_VERSION"), env!("GIT_HASH"))
-)]
+#[structopt(about = "A cd command that learns your habits", version = env!("ZOXIDE_VERSION"))]
 enum Zoxide {
     Add(subcommand::Add),
     Import(subcommand::Import),

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,10 @@ use anyhow::Result;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
-#[structopt(about = "A cd command that learns your habits")]
+#[structopt(
+    about = "A cd command that learns your habits",
+    version = concat!(env!("CARGO_PKG_VERSION"), env!("GIT_HASH"))
+)]
 enum Zoxide {
     Add(subcommand::Add),
     Import(subcommand::Import),


### PR DESCRIPTION
Users might file an issue while running an older version, but the issue
has already been fixed in master. Adding the git revision to the version
output will expedite this diagnosis. For example:

    $ zoxide -V
    zoxide 0.3.0-0191eea