### PR TITLE
Fix cd with path that contains spaces with bash

### DIFF
--- a/src/subcommand/init.rs
+++ b/src/subcommand/init.rs
@@ -201,7 +201,7 @@ _z_cd() {{
             return 1
         fi
     else
-        result="$(zoxide query "$@")" || return "$?"
+        result=$(zoxide query "$@") || return "$?"
         if [ -d "$result" ]; then
             _z_cd "$result" || return "$?"
         elif [ -n "$result" ]; then


### PR DESCRIPTION
Quote around $@ are not used correctly.

This quote is finished the quotation, not starting a new one--> "$@

So when a path like "This is a test" is passed to zoxide, what happens is
`zoxide query This is a test`
instead of
`zoxide query "This is a test"`

Quoting the whole things `$(cmd)` is not necessary, so just remove those quote fix the issue.
