### PR TITLE
Remove Windows verbatim drive in path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `zoxide remove` now throws an error if there was no match in the database.
 - Interactive mode in `zoxide` no longer throws an error if `fzf` exits gracefully.
+- Canonicalize to regular paths instead of UNC paths on Windows.
 
 ## [0.3.1] - 2020-04-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +437,7 @@ dependencies = [
  "bstr 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dunce 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -456,6 +462,7 @@ dependencies = [
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 "checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
+"checksum dunce 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0ad6bf6a88548d1126045c413548df1453d9be094a8ab9fd59bf1fdd338da4f"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = "1.0.28"
 bincode = "1.2.1"
 clap = "2.33.0"
 dirs = "2.0.2"
+dunce = "1.0"
 serde = { version = "1.0.106", features = ["derive"] }
 structopt = "0.3.12"
 uuid = { version = "0.8.1", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0.28"
 bincode = "1.2.1"
 clap = "2.33.0"
 dirs = "2.0.2"
-dunce = "1.0"
+dunce = "1.0.0"
 serde = { version = "1.0.106", features = ["derive"] }
 structopt = "0.3.12"
 uuid = { version = "0.8.1", features = ["v4"] }

--- a/src/db.rs
+++ b/src/db.rs
@@ -144,7 +144,7 @@ impl DB {
                             continue;
                         }
                     };
-                    let path_abs = match dunce::canonicalize(Path::new(path_str)) {
+                    let path_abs = match dunce::canonicalize(path_str) {
                         Ok(path) => path,
                         Err(e) => {
                             eprintln!("invalid path '{}' at line {}: {}", path_str, line_number, e);

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,6 @@
 use crate::config;
 use crate::dir::{Dir, Epoch, Rank};
+use crate::util;
 
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
@@ -188,6 +189,7 @@ impl DB {
         let path_abs = path
             .as_ref()
             .canonicalize()
+            .and_then(|path| Ok(util::remove_verbatim_disk_in_path(path)))
             .with_context(|| anyhow!("could not access directory: {}", path.as_ref().display()))?;
 
         match self.data.dirs.iter_mut().find(|dir| dir.path == path_abs) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, bail, Context, Result};
 
 use std::cmp::Reverse;
 use std::io::{Read, Write};
-use std::path::{Component, Path, PathBuf, Prefix};
+use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::SystemTime;
 
@@ -24,28 +24,6 @@ pub fn path_to_bytes<P: AsRef<Path>>(path: &P) -> Result<&[u8]> {
         Some(path_str) => Ok(path_str.as_bytes()),
         None => bail!("invalid Unicode in path"),
     }
-}
-
-#[cfg(not(windows))]
-pub fn remove_verbatim_disk_in_path(path: PathBuf) -> PathBuf {
-    path
-}
-
-#[cfg(windows)]
-pub fn remove_verbatim_disk_in_path(path: PathBuf) -> PathBuf {
-    let mut new_path = PathBuf::new();
-    for component in path.components() {
-        if let Component::Prefix(prefix) = component {
-            if let Prefix::VerbatimDisk(drive) = prefix.kind() {
-                new_path.push(format!("{}:", drive as char));
-                continue;
-            }
-        }
-
-        new_path.push(component);
-    }
-
-    new_path
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
`canonicalize` replaces the drive in a path with verbatim syntax,
e.g. `C:\Windows` turns into `\\?\C:\Windows`.

While Win32 apis handle verbatim paths nicely, commonly used Windows
shells like PowerShell and cmd do not, so we remove the prefix
before adding any paths to the database.