### PR TITLE
Fix `cd`ing home when no matching directory in `fish`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- When no match is found, `fish` stays in the current directory.
+- When no match is found, `fish` no longer `cd`s to the user's home.
 
 ## [0.3.1] - 2020-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Interactive mode in `zoxide` no longer throws an error if `fzf` exits gracefully.
 - Canonicalize to regular paths instead of UNC paths on Windows.
 
+### Fixed
+
+- When no match is found, `fish` stays in the current directory.
+
 ## [0.3.1] - 2020-04-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- When no match is found, `fish` no longer `cd`s to the user's home.
+- `fish` no longer `cd`s to the user's home when no match is found.
 
 ## [0.3.1] - 2020-04-03
 

--- a/src/subcommand/init.rs
+++ b/src/subcommand/init.rs
@@ -160,11 +160,15 @@ function {}
         or return $status
 
     else
+        # FIXME: use string-collect from fish 3.1.0 once it has wider adoption
+        set -l IFS ''
         set -l result (zoxide query $argv)
 
-        if begin; test -d $result; and string length -q -- $result; end
+        if test -d $result; and string length -q -- $result
             _z_cd $result
             or return $status
+        else if test -n "$result"
+            echo $result
         end
     end
 end

--- a/src/subcommand/init.rs
+++ b/src/subcommand/init.rs
@@ -160,15 +160,11 @@ function {}
         or return $status
 
     else
-        # FIXME: use string-collect from fish 3.1.0 once it has wider adoption
-        set -l IFS ''
         set -l result (zoxide query $argv)
 
-        if test -d $result
+        if begin; test -d $result; and string length -q -- $result; end
             _z_cd $result
             or return $status
-        else if test -n "$result"
-            echo $result
         end
     end
 end


### PR DESCRIPTION
Prior to this change, executing `z sjlk` (assuming no `sjlk` directory
in your database) would result in going back to the user's home.

---

I removed the following code because I was unable to reason about a situation when this branch would be reached (especially with the new changes). The only thing we should be printing to stdout (from a `zoxide query`) are paths; errors should be on stderr.

```fish
        else if test -n "$result"
            echo $result
```

In `fish`, if you run `test -d && echo hi`, you will see `hi` printed to stdout, which is the root cause of this issue. `test -z $result` and `test -n $result` both return `true`, so that's not useful to test the existence of a non-empty string. Probably a `fish` bug, but I've asked on their gitter and am awaiting response.

Additionally, I removed the `FIXME` related to `string-collect` because, as far as I can tell, it was for when we  had `query: ` in our output. Since that is no longer the case, I don't think there are any problems with dropping it and keeping the current solution.

---

If this is a problem in the other shells as well, I could fix those in this same PR. Tested POSIX w/ `dash` and not a problem there. Let me know about the others.