### PR TITLE
Aliases respect the z-cmd arg

### DIFF
--- a/src/subcommand/init/shell/fish.rs
+++ b/src/subcommand/init/shell/fish.rs
@@ -59,15 +59,15 @@ end
 fn alias(z_cmd: &str) -> String {
     format!(
         r#"
-abbr -a zi '{} -i'
+abbr -a {0}i '{0} -i'
 
-abbr -a za 'zoxide add'
+abbr -a {0}a 'zoxide add'
 
-abbr -a zq 'zoxide query'
-abbr -a zqi 'zoxide query -i'
+abbr -a {0}q 'zoxide query'
+abbr -a {0}qi 'zoxide query -i'
 
-abbr -a zr 'zoxide remove'
-abbr -a zri 'zoxide remove -i'
+abbr -a {0}r 'zoxide remove'
+abbr -a {0}ri 'zoxide remove -i'
 "#,
         z_cmd
     )

--- a/src/subcommand/init/shell/posix.rs
+++ b/src/subcommand/init/shell/posix.rs
@@ -52,15 +52,15 @@ _z_cd() {{
 fn alias(z_cmd: &str) -> String {
     format!(
         r#"
-alias zi='{} -i'
+alias {0}i='{0} -i'
 
-alias za='zoxide add'
+alias {0}a='zoxide add'
 
-alias zq='zoxide query'
-alias zqi='zoxide query -i'
+alias {0}q='zoxide query'
+alias {0}qi='zoxide query -i'
 
-alias zr='zoxide remove'
-alias zri='zoxide remove -i'
+alias {0}r='zoxide remove'
+alias {0}ri='zoxide remove -i'
 "#,
         z_cmd
     )


### PR DESCRIPTION
When changing the z-cmd to something like `j` instead, the aliases will
also use `j` as a prefix, e.g. `ji`, `ja`.

This is, in my opinion, less surprising than keeping the aliases
prefixed with `z` even after changing its command.