### PR TITLE
Add `windows-msvc` cargo build target to GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,11 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --target x86_64-pc-windows-msvc
+          args: --release --target x86_64-pc-windows-gnu
       - uses: actions/upload-artifact@v1.0.0
         with:
-          name: "zoxide-x86_64-pc-windows-msvc"
-          path: "target/x86_64-pc-windows-msvc/release/zoxide"
+          name: "zoxide-x86_64-pc-windows-gnu.exe"
+          path: "target/x86_64-pc-windows-gnu/release/zoxide.exe"
           
   release-upload:
     needs:
@@ -113,12 +113,12 @@ jobs:
 
       - uses: actions/download-artifact@v1
         with:
-          name: "zoxide-x86_64-pc-windows-msvc"
+          name: "zoxide-x86_64-pc-windows-gnu.exe"
       - uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: "zoxide-x86_64-pc-windows-msvc/zoxide"
-          asset_name: "zoxide-x86_64-pc-windows-msvc"
+          asset_path: "zoxide-x86_64-pc-windows-gnu/zoxide"
+          asset_name: "zoxide-x86_64-pc-windows-gnu.exe"
           asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,11 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --target x86_64-pc-windows-gnu
+          args: --release --target x86_64-pc-windows-msvc
       - uses: actions/upload-artifact@v1.0.0
         with:
-          name: "zoxide-x86_64-pc-windows-gnu.exe"
-          path: "target/x86_64-pc-windows-gnu/release/zoxide.exe"
+          name: "zoxide-x86_64-pc-windows-msvc.exe"
+          path: "target/x86_64-pc-windows-msvc/release/zoxide.exe"
           
   release-upload:
     needs:
@@ -113,12 +113,12 @@ jobs:
 
       - uses: actions/download-artifact@v1
         with:
-          name: "zoxide-x86_64-pc-windows-gnu.exe"
+          name: "zoxide-x86_64-pc-windows-msvc.exe"
       - uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: "zoxide-x86_64-pc-windows-gnu/zoxide"
-          asset_name: "zoxide-x86_64-pc-windows-gnu.exe"
+          asset_path: "zoxide-x86_64-pc-windows-msvc/zoxide"
+          asset_name: "zoxide-x86_64-pc-windows-msvc.exe"
           asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,24 @@ jobs:
           name: "zoxide-x86_64-apple-darwin"
           path: "target/x86_64-apple-darwin/release/zoxide"
 
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target x86_64-pc-windows-msvc
+      - uses: actions/upload-artifact@v1.0.0
+        with:
+          name: "zoxide-x86_64-pc-windows-msvc"
+          path: "target/x86_64-pc-windows-msvc/release/zoxide"
+          
   release-upload:
     needs:
       - build-linux
       - build-darwin
+      - build-windows
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -95,4 +109,16 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: "zoxide-x86_64-apple-darwin/zoxide"
           asset_name: "zoxide-x86_64-apple-darwin"
+          asset_content_type: application/octet-stream
+
+      - uses: actions/download-artifact@v1
+        with:
+          name: "zoxide-x86_64-pc-windows-msvc"
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: "zoxide-x86_64-pc-windows-msvc/zoxide"
+          asset_name: "zoxide-x86_64-pc-windows-msvc"
           asset_content_type: application/octet-stream


### PR DESCRIPTION
Tested on my fork, seems to be compiling normally.

![image](https://user-images.githubusercontent.com/32114380/84463150-702f0d80-aca3-11ea-878a-29bac35757e5.png)

> Related run: [actions/runs/132906410](https://github.com/spencerwooo/zoxide/actions/runs/132906410)