### PR TITLE
Cleanup temporary $result variables

### DIFF
--- a/src/subcommand/init/shell/fish.rs
+++ b/src/subcommand/init/shell/fish.rs
@@ -41,13 +41,13 @@ function {}
     else
         # FIXME: use string-collect from fish 3.1.0 once it has wider adoption
         set -l IFS ''
-        set -l result (zoxide query $argv)
+        set -l _zoxide_result (zoxide query $argv)
 
-        if test -d $result; and string length -q -- $result
-            _z_cd $result
+        if test -d $_zoxide_result; and string length -q -- $_zoxide_result
+            _z_cd $_zoxide_result
             or return $status
-        else if test -n "$result"
-            echo $result
+        else if test -n "$_zoxide_result"
+            echo $_zoxide_result
         end
     end
 end

--- a/src/subcommand/init/shell/posix.rs
+++ b/src/subcommand/init/shell/posix.rs
@@ -37,12 +37,13 @@ _z_cd() {{
             return 1
         fi
     else
-        result="$(zoxide query "$@")" || return "$?"
-        if [ -d "$result" ]; then
-            _z_cd "$result" || return "$?"
-        elif [ -n "$result" ]; then
-            echo "$result"
+        _zoxide_result="$(zoxide query "$@")" || return "$?"
+        if [ -d "$_zoxide_result" ]; then
+            _z_cd "$_zoxide_result" || return "$?"
+        elif [ -n "$_zoxide_result" ]; then
+            echo "$_zoxide_result"
         fi
+        unset _zoxide_result
     fi
 }}
 "#,

--- a/src/subcommand/init/shell/powershell.rs
+++ b/src/subcommand/init/shell/powershell.rs
@@ -31,11 +31,11 @@ function {} {{
         z_cd -
     }}
     else {{
-        $result = zoxide query @args
-        if ($LASTEXITCODE -eq 0 -and $result -is [string] -and (Test-Path $result)) {{
-            z_cd $result
+        $_zoxide_result = zoxide query @args
+        if ($LASTEXITCODE -eq 0 -and $_zoxide_result -is [string] -and (Test-Path $_zoxide_result)) {{
+            z_cd $_zoxide_result
         }} else {{
-            $result
+            $_zoxide_result
         }}
     }}
 }}


### PR DESCRIPTION
After we call `$(zoxide query $input)`, we store it in `$result` in all
shells. This `result` environment variables survives after the call.

To fix this undesirable behavior, we rename the temporary variable to
something less ubiquitous (`_ZO_RESULT`,) as well as unset it after the
`cd`/`echo` has been done.

For the record, I noticed this because I use `%~` in my zsh `PS1`, which
has a tendency to re-use set environment variables in the path, ie:

```
pete:~$ z code/misc/rustyline
pete:~/code/misc/rustyline$ z
pete:~$ z rusty
pete:~result$ _
```

As you can see, on the second cd, the prompt path is `result`. This
hides the prompt information. I have not tested the fish and powershell
implementations, as I do not have the capabilities to do so.