### PR TITLE
README: add instructions on installing via MacPorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ brew tap ajeetdsouza/zoxide
 brew install zoxide
 ```
 
+#### On macOS (via MacPorts)
+
+```
+port selfupdate
+port install zoxide
+```
+
 #### On NixOS
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -85,8 +85,7 @@ brew install zoxide
 
 #### On macOS (via MacPorts)
 
-```
-port selfupdate
+```sh
 port install zoxide
 ```
 


### PR DESCRIPTION
[`zoxide` is now in Macports](https://ports.macports.org/port/zoxide/summary).  This PR adds instructions on how would install in this way.