### PR TITLE
_zoxide_hook ignore $? when running, adding a small way around to get it

### DIFF
--- a/src/subcommand/init/shell/bash.rs
+++ b/src/subcommand/init/shell/bash.rs
@@ -37,7 +37,7 @@ _zoxide_hook() {
 
 case "$PROMPT_COMMAND" in
     *_zoxide_hook*) ;;
-    *) PROMPT_COMMAND="_zoxide_hook${PROMPT_COMMAND:+;${PROMPT_COMMAND}}" ;;
+    *) PROMPT_COMMAND="${PROMPT_COMMAND:+${PROMPT_COMMAND};}_zoxide_hook" ;;
 esac
 "#;
 


### PR DESCRIPTION
# Problem
In my prompt, I display the return value of the last command but  _zoxide_hook ignore it.

# Solution
I've added a small workaround to get the correct value and not the one of zoxide.

I mainly use Bash and not other shell. Therefore, I could not fully test on POSIX or zsh shell.
I also could not implement it for Fish.

Comment are welcome