### PR TITLE
Start fish in an isolated env

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -143,9 +143,13 @@ mod tests {
                 #[test]
                 fn fish_fish_#i() {
                     let opts = dbg!(&opts()[i]);
+                    let home = tempfile::tempdir().unwrap();
+                    let home = home.path();
                     let source = Fish(opts).render().unwrap();
                     Command::new("fish")
                         .args(&["--command", &source, "--private"])
+                        .env_clear()
+                        .env("HOME", home)
                         .assert()
                         .success()
                         .stdout("")


### PR DESCRIPTION
`fish` in CI complains because the default `$HOME` directory denies any program write access. This PR would create a tempdir for fish to run in.