### PR TITLE
Forcibly disable backtraces

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,9 +13,13 @@ use crate::error::SilentExit;
 use anyhow::Result;
 use clap::Clap;
 
+use std::env;
 use std::process;
 
 pub fn main() -> Result<()> {
+    env::remove_var("RUST_LIB_BACKTRACE");
+    env::remove_var("RUST_BACKTRACE");
+
     App::parse()
         .run()
         .map_err(|e| match e.downcast::<SilentExit>() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use std::env;
 use std::process;
 
 pub fn main() -> Result<()> {
+    // Forcibly disable backtraces.
     env::remove_var("RUST_LIB_BACKTRACE");
     env::remove_var("RUST_BACKTRACE");
 


### PR DESCRIPTION
Fixes https://github.com/ajeetdsouza/zoxide/issues/129. If there is need for backtraces at some point, we can create a separate environment variable for them.