### PR TITLE
Add Alpine Linux installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ If you would rather not run a script, you can download the binary from the [Rele
 | --------------- | --------------------- | --------------------------------------------------------- |
 | **Any**         | [crates.io]           | `cargo install zoxide`                                    |
 | **Any**         | [Linuxbrew]           | `brew install zoxide`                                     |
+| Alpine Linux    | [Alpine Linux Packages] (since Alpine 3.13) | `apk add zoxide`                    |
 | Arch Linux      | [AUR]                 | `yay -Sy zoxide-bin`                                      |
 | CentOS          | [Copr]                | `dnf copr enable atim/zoxide` <br /> `dnf install zoxide` |
 | Debian Unstable | [Debian Packages]     | `apt install zoxide`                                      |
@@ -200,6 +201,7 @@ eval "$(zoxide init posix --hook prompt)"
 - `$_ZO_MAXAGE`: sets the maximum total age after which entries start getting deleted
 - `$_ZO_RESOLVE_SYMLINKS`: when set to `1`, `z add` will resolve symlinks.
 
+[Alpine Linux Packages]: https://pkgs.alpinelinux.org/package/edge/community/x86_64/zoxide
 [AUR]: https://aur.archlinux.org/packages/zoxide-bin
 [Copr]: https://copr.fedorainfracloud.org/coprs/atim/zoxide/
 [crates.io]: https://crates.io/crates/zoxide

--- a/README.md
+++ b/README.md
@@ -59,17 +59,17 @@ If you would rather not run a script, you can download the binary from the [Rele
 <!-- omit in toc -->
 #### On Linux
 
-| Distribution    | Repository            | Instructions                                              |
-| --------------- | --------------------- | --------------------------------------------------------- |
-| **Any**         | [crates.io]           | `cargo install zoxide`                                    |
-| **Any**         | [Linuxbrew]           | `brew install zoxide`                                     |
-| Alpine Linux    | [Alpine Linux Packages] (since Alpine 3.13) | `apk add zoxide`                    |
-| Arch Linux      | [AUR]                 | `yay -Sy zoxide-bin`                                      |
-| CentOS          | [Copr]                | `dnf copr enable atim/zoxide` <br /> `dnf install zoxide` |
-| Debian Unstable | [Debian Packages]     | `apt install zoxide`                                      |
-| Fedora          | [Fedora Packages]     | `dnf install zoxide`                                      |
-| NixOS           | [nixpkgs]             | `nix-env -iA nixpkgs.zoxide`                              |
-| Void Linux      | [Void Linux Packages] | `xbps-install -S zoxide`                                  |
+| Distribution      | Repository              | Instructions                                              |
+| ----------------- | ----------------------- | --------------------------------------------------------- |
+| **Any**           | [crates.io]             | `cargo install zoxide`                                    |
+| **Any**           | [Linuxbrew]             | `brew install zoxide`                                     |
+| Alpine Linux Edge | [Alpine Linux Packages] | `apk add zoxide`                                          |
+| Arch Linux        | [AUR]                   | `yay -Sy zoxide-bin`                                      |
+| CentOS            | [Copr]                  | `dnf copr enable atim/zoxide` <br /> `dnf install zoxide` |
+| Debian Unstable   | [Debian Packages]       | `apt install zoxide`                                      |
+| Fedora            | [Fedora Packages]       | `dnf install zoxide`                                      |
+| NixOS             | [nixpkgs]               | `nix-env -iA nixpkgs.zoxide`                              |
+| Void Linux        | [Void Linux Packages]   | `xbps-install -S zoxide`                                  |
 
 <!-- omit in toc -->
 #### On macOS


### PR DESCRIPTION
Note: Alpine 3.13 has not been released yet, it should be till the end of this year.