### PR TITLE
Add export subcommand

### DIFF
--- a/src/cmd/export.rs
+++ b/src/cmd/export.rs
@@ -1,0 +1,27 @@
+use super::Cmd;
+use crate::config;
+
+use crate::store::Store;
+use anyhow::{Context, Result};
+use clap::Clap;
+
+use std::io::{self, Write};
+
+/// Export entries from database
+#[derive(Clap, Debug)]
+pub struct Export {}
+
+impl Cmd for Export {
+    fn run(&self) -> Result<()> {
+        let data_dir = config::zo_data_dir()?;
+        let store = Store::open(&data_dir)?;
+
+        let mut handle = io::stdout();
+        for dir in store.dirs.iter() {
+            writeln!(handle, "{}|{}|{}", dir.path, dir.rank, dir.last_accessed)
+                .context("could not write to stdout")?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 mod add;
+mod export;
 mod import;
 mod init;
 mod query;
@@ -8,6 +9,7 @@ use anyhow::Result;
 use clap::{AppSettings, Clap};
 
 pub use add::Add;
+pub use export::Export;
 pub use import::Import;
 pub use init::Init;
 pub use query::Query;
@@ -21,6 +23,7 @@ pub trait Cmd {
 #[clap(about, author, global_setting(AppSettings::GlobalVersion), global_setting(AppSettings::VersionlessSubcommands), version = env!("ZOXIDE_VERSION"))]
 pub enum App {
     Add(Add),
+    Export(Export),
     Import(Import),
     Init(Init),
     Query(Query),
@@ -31,6 +34,7 @@ impl Cmd for App {
     fn run(&self) -> Result<()> {
         match self {
             App::Add(cmd) => cmd.run(),
+            App::Export(cmd) => cmd.run(),
             App::Import(cmd) => cmd.run(),
             App::Init(cmd) => cmd.run(),
             App::Query(cmd) => cmd.run(),


### PR DESCRIPTION
This is a simple addition, and it could even be a standalone tool. But I agree with [@ahmedelgabri's concern](https://github.com/ajeetdsouza/zoxide/issues/11#issuecomment-598896508), this should belong to zoxide.

The `export` subcommand outputs the same format as most `z` implementations such as rupa/z:

```
/home/runner/work/fastmac/fastmac|1|1608511969
/home/runner/.local/share|3|1608511994
/home/runner/.nvm|3|1608511986
/home/runner/.ssh|1|1608511984
```