### PR TITLE
Use /dev/null on Unix shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed unnecessary backtraces on Rust nightly.
 - Fixed generated shell code to avoid accidentally using aliased builtins.
 - Handle broken pipe errors gracefully when writing to streams.
+- NUL file appearing in working directory on Windows.
 
 ## [0.5.0] - 2020-10-30
 

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -8,13 +8,6 @@ pub struct Opts<'a> {
     pub resolve_symlinks: bool,
 }
 
-impl Opts<'_> {
-    #[cfg(unix)]
-    pub const DEVNULL: &'static str = "/dev/null";
-    #[cfg(windows)]
-    pub const DEVNULL: &'static str = "NUL";
-}
-
 macro_rules! make_template {
     ($name:ident, $path:expr) => {
         #[derive(::std::fmt::Debug, ::askama::Template)]

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -66,10 +66,10 @@ mod tests {
                     for &hook in HOOKS {
                         for &cmd in CMDS {
                             let opt = Opts {
+                                cmd,
+                                hook,
                                 echo,
                                 resolve_symlinks,
-                                hook,
-                                cmd,
                             };
                             opts.push(opt);
                         }

--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -124,9 +124,9 @@ function __zoxide_zri() {
 # Remove definitions.
 function __zoxide_unset() {
     # shellcheck disable=SC1001
-    \builtin unset -f "$@" &>{{ Opts::DEVNULL }}
+    \builtin unset -f "$@" &>/dev/null
     # shellcheck disable=SC1001
-    \builtin unset -v "$@" &>{{ Opts::DEVNULL }}
+    \builtin unset -v "$@" &>/dev/null
 }
 
 __zoxide_unset '{{cmd}}'

--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -104,9 +104,9 @@ end
 
 # Remove definitions.
 function __zoxide_unset
-    set --erase $argv > {{ Opts::DEVNULL }} 2>&1
-    abbr --erase $argv > {{ Opts::DEVNULL }} 2>&1
-    builtin functions --erase $argv > {{ Opts::DEVNULL }} 2>&1
+    set --erase $argv > /dev/null 2>&1
+    abbr --erase $argv > /dev/null 2>&1
+    builtin functions --erase $argv > /dev/null 2>&1
 end
 
 __zoxide_unset '{{cmd}}'

--- a/templates/posix.txt
+++ b/templates/posix.txt
@@ -126,9 +126,9 @@ __zoxide_zri() {
 # Remove definitions.
 __zoxide_unset() {
     # shellcheck disable=SC1001
-    \unset -f "$@" >{{ Opts::DEVNULL }} 2>&1
+    \unset -f "$@" >/dev/null 2>&1
     # shellcheck disable=SC1001
-    \unset -v "$@" >{{ Opts::DEVNULL }} 2>&1
+    \unset -v "$@" >/dev/null 2>&1
 }
 
 __zoxide_unset '{{cmd}}'

--- a/templates/xonsh.txt
+++ b/templates/xonsh.txt
@@ -16,7 +16,7 @@ from builtins import events  # type: ignore # pylint: disable=no-name-in-module
 from subprocess import CalledProcessError
 from typing import AnyStr, List, Optional
 
-import xonsh.dirstack  # type: ignore
+import xonsh.dirstack  # type: ignore # pylint: disable=import-error
 
 {{ SECTION }}
 # Utility functions for zoxide.

--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -107,9 +107,9 @@ function __zoxide_zri() {
 
 # Remove definitions.
 function __zoxide_unset() {
-    \builtin unalias "$@" &>{{ Opts::DEVNULL }}
-    \builtin unfunction "$@" &>{{ Opts::DEVNULL }}
-    \builtin unset "$@" &>{{ Opts::DEVNULL }}
+    \builtin unalias "$@" &>/dev/null
+    \builtin unfunction "$@" &>/dev/null
+    \builtin unset "$@" &>/dev/null
 }
 
 __zoxide_unset '{{cmd}}'


### PR DESCRIPTION
Fixes #150.

Earlier, shells would use `/dev/null` on Linux and `NUL` on Windows. This is unnecessary, because these shells don't support Windows. They are only run on Windows using a POSIX emulation layer like `MSYS2`, which would also use `/dev/null`.