### PR TITLE
Use variable to prevent hook redefinition

### DIFF
--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -51,10 +51,10 @@ function __zoxide_hook() {
 {{ NOT_CONFIGURED }}
 
 {%- else %}
-case "${PROMPT_COMMAND}" in
-    *__zoxide_hook*) ;;
-    *) PROMPT_COMMAND="${PROMPT_COMMAND:+${PROMPT_COMMAND};}__zoxide_hook" ;;
-esac
+if [ "${__zoxide_hooked}" != '1' ]; then
+    PROMPT_COMMAND="${PROMPT_COMMAND:+${PROMPT_COMMAND};}__zoxide_hook"
+    __zoxide_hooked='1'
+fi
 
 {%- endif %}
 

--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -47,16 +47,14 @@ function __zoxide_hook() {
 {%- endmatch %}
 
 # Initialize hook.
-{%- if hook == Hook::None %}
-{{ NOT_CONFIGURED }}
-
-{%- else %}
 if [ "${__zoxide_hooked}" != '1' ]; then
-    PROMPT_COMMAND="${PROMPT_COMMAND:+${PROMPT_COMMAND};}__zoxide_hook"
     __zoxide_hooked='1'
+    {%- if hook == Hook::None %}
+    {{ NOT_CONFIGURED }}
+    {%- else %}
+    PROMPT_COMMAND="${PROMPT_COMMAND:+${PROMPT_COMMAND};}__zoxide_hook"
+    {%- endif %}
 fi
-
-{%- endif %}
 
 {{ SECTION }}
 # When using zoxide with --no-aliases, alias these internal functions as
@@ -72,7 +70,7 @@ function __zoxide_z() {
             __zoxide_cd "${OLDPWD}"
         else
             # shellcheck disable=SC2016
-            \builtin echo 'zoxide: $OLDPWD is not set'
+            \builtin printf 'zoxide: $OLDPWD is not set\n'
             return 1
         fi
     elif [ "$#" -eq 1 ] && [ -d "$1" ]; then

--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -30,18 +30,18 @@ end
 #
 
 # Initialize hook to add new entries to the database.
-{%- match hook %}
-{%- when Hook::None %}
-function __zoxide_hook
-
-{%- when Hook::Prompt %}
-function __zoxide_hook --on-event fish_prompt
-
-{%- when Hook::Pwd %}
-function __zoxide_hook --on-variable PWD
-
-{%- endmatch %}
-    command zoxide add (__zoxide_pwd)
+if test "$__zoxide_hooked" != '1'
+    set __zoxide_hooked '1'
+    {%- match hook %}
+    {%- when Hook::None %}
+    function __zoxide_hook
+    {%- when Hook::Prompt %}
+    function __zoxide_hook --on-event fish_prompt
+    {%- when Hook::Pwd %}
+    function __zoxide_hook --on-variable PWD
+    {%- endmatch %}
+        command zoxide add (__zoxide_pwd)
+    end
 end
 
 {{ SECTION }}

--- a/templates/posix.txt
+++ b/templates/posix.txt
@@ -1,13 +1,6 @@
 {%- let SECTION = "# =============================================================================\n#" -%}
 {%- let NOT_CONFIGURED = "# -- not configured --" -%}
 
-{%- if hook == Hook::Pwd -%}
-\echo "\
-zoxide: PWD hooks are not supported on POSIX shells.
-        Use '--hook prompt' when initializing zoxide."
-
-{% endif -%}
-
 {{ SECTION }}
 # Utility functions for zoxide.
 #
@@ -47,20 +40,19 @@ __zoxide_hook() {
 {%- endmatch %}
 
 # Initialize hook.
-{%- match hook %}
-{%- when Hook::None %}
-{{ NOT_CONFIGURED }}
-
-{%- when Hook::Prompt %}
 if [ "${__zoxide_hooked}" != '1' ]; then
-    PS1="${PS1}\$(__zoxide_hook)"
     __zoxide_hooked='1'
+    {%- match hook %}
+    {%- when Hook::None %}
+    {{ NOT_CONFIGURED }}
+    {%- when Hook::Prompt %}
+    PS1="${PS1}\$(__zoxide_hook)"
+    {%- when Hook::Pwd %}
+    \printf "%s\n%s\n" \
+        "zoxide: PWD hooks are not supported on POSIX shells." \
+        "        Use '--hook prompt' when initializing zoxide."
+    {%- endmatch %}
 fi
-
-{%- when Hook::Pwd %}
-{{ NOT_CONFIGURED }}
-
-{%- endmatch %}
 
 {{ SECTION }}
 # When using zoxide with --no-aliases, alias these internal functions as
@@ -76,7 +68,7 @@ __zoxide_z() {
             __zoxide_cd "${OLDPWD}"
         else
             # shellcheck disable=SC2016
-            \echo 'zoxide: $OLDPWD is not set'
+            \printf 'zoxide: $OLDPWD is not set'
             return 1
         fi
     elif [ "$#" -eq 1 ] && [ -d "$1" ]; then

--- a/templates/posix.txt
+++ b/templates/posix.txt
@@ -52,10 +52,10 @@ __zoxide_hook() {
 {{ NOT_CONFIGURED }}
 
 {%- when Hook::Prompt %}
-case "${PS1}" in
-    *\$\(__zoxide_hook\)*) ;;
-    *) PS1="${PS1}\$(__zoxide_hook)" ;;
-esac
+if [ "${__zoxide_hooked}" != '1' ]; then
+    PS1="${PS1}\$(__zoxide_hook)"
+    __zoxide_hooked='1'
+fi
 
 {%- when Hook::Pwd %}
 {{ NOT_CONFIGURED }}

--- a/templates/powershell.txt
+++ b/templates/powershell.txt
@@ -28,29 +28,29 @@ function __zoxide_hook {
 }
 
 # Initialize hook.
-{%- match hook %}
-{%- when Hook::None %}
-{{ NOT_CONFIGURED }}
-
-{%- when Hook::Prompt %}
-$PreZoxidePrompt = $function:prompt
-function prompt {
-    $null = __zoxide_hook
-    & $PreZoxidePrompt
-}
-
-{%- when Hook::Pwd %}
-if ($PSVersionTable.PSVersion.Major -ge 6) {
-    $ExecutionContext.InvokeCommand.LocationChangedAction = {
+if ($__zoxide_hooked -ne '1') {
+    $__zoxide_hooked = '1'
+    {%- match hook %}
+    {%- when Hook::None %}
+    {{ NOT_CONFIGURED }}
+    {%- when Hook::Prompt %}
+    $__zoxide_prompt_old = $function:prompt
+    function prompt {
         $null = __zoxide_hook
+        & $__zoxide_prompt_old
     }
-} else {
-    Write-Error "`
-zoxide: PWD hooks are not supported below PowerShell 6.
-        Use '--hook prompt' when initializing zoxide."
+    {%- when Hook::Pwd %}
+    if ($PSVersionTable.PSVersion.Major -ge 6) {
+        $ExecutionContext.InvokeCommand.LocationChangedAction = {
+            $null = __zoxide_hook
+        }
+    } else {
+        Write-Error ("`n" +
+            "zoxide: PWD hooks are not supported below PowerShell 6.`n" +
+            "        Use '--hook prompt' when initializing zoxide.")
+    }
+    {%- endmatch %}
 }
-
-{%- endmatch %}
 
 {{ SECTION }}
 # When using zoxide with --no-aliases, alias these internal functions as

--- a/templates/xonsh.txt
+++ b/templates/xonsh.txt
@@ -76,21 +76,21 @@ def __zoxide_errhandler(func):
 #
 
 # Initialize hook to add new entries to the database.
-{%- match hook %}
-{%- when Hook::None %}
-{{ NOT_CONFIGURED }}
+if globals().get("__zoxide_hooked") is not True:
+    globals()["__zoxide_hooked"] = True
 
-{%- when Hook::Prompt %}
-@events.on_post_prompt  # type: ignore  # pylint:disable=undefined-variable
-
-{%- when Hook::Pwd %}
-@events.on_chdir  # type: ignore  # pylint:disable=undefined-variable
-
-{%- endmatch %}
-def __zoxide_hook(**_kwargs):
-    """Hook to add new entries to the database."""
-    pwd = __zoxide_pwd()
-    subprocess.run(["zoxide", "add", pwd], check=False)
+    {% match hook -%}
+    {%- when Hook::None -%}
+    {{ NOT_CONFIGURED }}
+    {%- when Hook::Prompt -%}
+    @events.on_post_prompt  # type: ignore  # pylint:disable=undefined-variable
+    {%- when Hook::Pwd -%}
+    @events.on_chdir  # type: ignore  # pylint:disable=undefined-variable
+    {%- endmatch %}
+    def __zoxide_hook(**_kwargs):
+        """Hook to add new entries to the database."""
+        pwd = __zoxide_pwd()
+        subprocess.run(["zoxide", "add", pwd], check=False)
 
 
 {{ SECTION }}

--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -29,19 +29,17 @@ function __zoxide_hook() {
 }
 
 # Initialize hook.
-{%- match hook %}
-{%- when Hook::None %}
-{{ NOT_CONFIGURED }}
-
-{%- when Hook::Prompt %}
-[[ -n "${precmd_functions[(r)__zoxide_hook]}" ]] || {
+if [ "${__zoxide_hooked}" != '1' ]; then
+    __zoxide_hooked='1'
+    {%- match hook %}
+    {%- when Hook::None %}
+    {{ NOT_CONFIGURED }}
+    {%- when Hook::Prompt %}
     precmd_functions+=(__zoxide_hook)
-}
-
-{%- when Hook::Pwd %}
-chpwd_functions=(${chpwd_functions[@]} "__zoxide_hook")
-
-{%- endmatch %}
+    {%- when Hook::Pwd %}
+    chpwd_functions=(${chpwd_functions[@]} "__zoxide_hook")
+    {%- endmatch %}
+fi
 
 {{ SECTION }}
 # When using zoxide with --no-aliases, alias these internal functions as
@@ -56,7 +54,7 @@ function __zoxide_z() {
         if [ -n "$OLDPWD" ]; then
             __zoxide_cd "$OLDPWD"
         else
-            \builtin echo 'zoxide: \$OLDPWD is not set'
+            \builtin printf 'zoxide: $OLDPWD is not set'
             return 1
         fi
     elif [ "$#" -eq 1 ] &&  [ -d "$1" ]; then


### PR DESCRIPTION
Fixes https://github.com/ajeetdsouza/zoxide/issues/147.

Earlier, we were using failure-prone magic to test if the hook had already been defined. In this PR, I've added a new `__zoxide_hooked` variable that checks if the hook has already been defined, and skips it if it is.