### PR TITLE
Remove barely-used aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Removed unnecessary backtraces on Rust nightly.
+- Removed backtraces on Rust nightly.
 - Fixed generated shell code to avoid accidentally using aliased builtins.
 - Handle broken pipe errors gracefully when writing to streams.
 - NUL file appearing in working directory on Windows.
+- Accidental redefinition of hooks when initialized twice on some shells.
+
+### Removed
+
+- Aliases: `za`, `zq`, `zqi`, `zr`, `zri`.
 
 ## [0.5.0] - 2020-10-30
 

--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -87,31 +87,6 @@ function __zoxide_zi() {
     __zoxide_result="$(zoxide query -i -- "$@")" && __zoxide_cd "${__zoxide_result}"
 }
 
-# Add a new entry to the database.
-function __zoxide_za() {
-    zoxide add "$@"
-}
-
-# Query an entry from the database using only keywords.
-function __zoxide_zq() {
-    zoxide query "$@"
-}
-
-# Query an entry from the database using interactive selection.
-function __zoxide_zqi() {
-    zoxide query -i "$@"
-}
-
-# Remove an entry from the database using the exact path.
-function __zoxide_zr() {
-    zoxide remove "$@"
-}
-
-# Remove an entry from the database using interactive selection.
-function __zoxide_zri() {
-    zoxide remove -i "$@"
-}
-
 {{ SECTION }}
 # Convenient aliases for zoxide. Disable these using --no-aliases.
 #
@@ -135,31 +110,6 @@ function {{cmd}}() {
 __zoxide_unset '{{cmd}}i'
 function {{cmd}}i() {
     __zoxide_zi "$@"
-}
-
-__zoxide_unset '{{cmd}}a'
-function {{cmd}}a() {
-    __zoxide_za "$@"
-}
-
-__zoxide_unset '{{cmd}}q'
-function {{cmd}}q() {
-    __zoxide_zq "$@"
-}
-
-__zoxide_unset '{{cmd}}qi'
-function {{cmd}}qi() {
-    __zoxide_zqi "$@"
-}
-
-__zoxide_unset '{{cmd}}r'
-function {{cmd}}r() {
-    __zoxide_zr "$@"
-}
-
-__zoxide_unset '{{cmd}}ri'
-function {{cmd}}ri() {
-    __zoxide_zri "$@"
 }
 
 {%- when None %}

--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -70,31 +70,6 @@ function __zoxide_zi
     and __zoxide_cd $__zoxide_result
 end
 
-# Add a new entry to the database.
-function __zoxide_za
-    command zoxide add $argv
-end
-
-# Query an entry from the database using only keywords.
-function __zoxide_zq
-    command zoxide query $argv
-end
-
-# Query an entry from the database using interactive selection.
-function __zoxide_zqi
-    command zoxide query -i $argv
-end
-
-# Remove an entry from the database using the exact path.
-function __zoxide_zr
-    command zoxide remove $argv
-end
-
-# Remove an entry from the database using interactive selection.
-function __zoxide_zri
-    command zoxide remove -i $argv
-end
-
 {{ SECTION }}
 # Convenient aliases for zoxide. Disable these using --no-aliases.
 #
@@ -117,31 +92,6 @@ end
 __zoxide_unset '{{cmd}}i'
 function {{cmd}}i
     __zoxide_zi $argv
-end
-
-__zoxide_unset '{{cmd}}a'
-function {{cmd}}a
-    __zoxide_za $argv
-end
-
-__zoxide_unset '{{cmd}}q'
-function {{cmd}}q
-    __zoxide_zq $argv
-end
-
-__zoxide_unset '{{cmd}}qi'
-function {{cmd}}qi
-    __zoxide_zqi $argv
-end
-
-__zoxide_unset '{{cmd}}r'
-function {{cmd}}r
-    __zoxide_zr $argv
-end
-
-__zoxide_unset '{{cmd}}ri'
-function {{cmd}}ri
-    __zoxide_zri $argv
 end
 
 {%- when None %}

--- a/templates/posix.txt
+++ b/templates/posix.txt
@@ -50,7 +50,7 @@ if [ "${__zoxide_hooked}" != '1' ]; then
     {%- when Hook::Pwd %}
     \printf "%s\n%s\n" \
         "zoxide: PWD hooks are not supported on POSIX shells." \
-        "        Use '--hook prompt' when initializing zoxide."
+        "        Use 'zoxide init posix --hook prompt' instead."
     {%- endmatch %}
 fi
 
@@ -83,31 +83,6 @@ __zoxide_zi() {
     __zoxide_result="$(zoxide query -i -- "$@")" && __zoxide_cd "${__zoxide_result}"
 }
 
-# Add a new entry to the database.
-__zoxide_za() {
-    zoxide add "$@"
-}
-
-# Query an entry from the database using only keywords.
-__zoxide_zq() {
-    zoxide query "$@"
-}
-
-# Query an entry from the database using interactive selection.
-__zoxide_zqi() {
-    zoxide query -i "$@"
-}
-
-# Remove an entry from the database using the exact path.
-__zoxide_zr() {
-    zoxide remove "$@"
-}
-
-# Remove an entry from the database using interactive selection.
-__zoxide_zri() {
-    zoxide remove -i "$@"
-}
-
 {{ SECTION }}
 # Convenient aliases for zoxide. Disable these using --no-aliases.
 #
@@ -131,31 +106,6 @@ __zoxide_unset '{{cmd}}'
 __zoxide_unset '{{cmd}}i'
 {{cmd}}i() {
     __zoxide_zi "$@"
-}
-
-__zoxide_unset '{{cmd}}a'
-{{cmd}}a() {
-    __zoxide_za "$@"
-}
-
-__zoxide_unset '{{cmd}}q'
-{{cmd}}q() {
-    __zoxide_zq "$@"
-}
-
-__zoxide_unset '{{cmd}}qi'
-{{cmd}}qi() {
-    __zoxide_zqi "$@"
-}
-
-__zoxide_unset '{{cmd}}r'
-{{cmd}}r() {
-    __zoxide_zr "$@"
-}
-
-__zoxide_unset '{{cmd}}ri'
-{{cmd}}ri() {
-    __zoxide_zri "$@"
 }
 
 {%- when None %}

--- a/templates/powershell.txt
+++ b/templates/powershell.txt
@@ -47,7 +47,7 @@ if ($__zoxide_hooked -ne '1') {
     } else {
         Write-Error ("`n" +
             "zoxide: PWD hooks are not supported below PowerShell 6.`n" +
-            "        Use '--hook prompt' when initializing zoxide.")
+            "        Use 'zoxide init powershell --hook prompt' instead.")
     }
     {%- endmatch %}
 }
@@ -84,31 +84,6 @@ function __zoxide_zi {
     }
 }
 
-# Add a new entry to the database.
-function __zoxide_za {
-    zoxide add @args
-}
-
-# Query an entry from the database using only keywords.
-function __zoxide_zq {
-    zoxide query @args
-}
-
-# Query an entry from the database using interactive selection.
-function __zoxide_zqi {
-    zoxide query -i @args
-}
-
-# Remove an entry from the database using the exact path.
-function __zoxide_zr {
-    zoxide remove @args
-}
-
-# Remove an entry from the database using interactive selection.
-function __zoxide_zri {
-    zoxide remove -i @args
-}
-
 {{ SECTION }}
 # Convenient aliases for zoxide. Disable these using --no-aliases.
 #
@@ -118,14 +93,6 @@ function __zoxide_zri {
 
 Set-Alias {{cmd}} __zoxide_z
 Set-Alias {{cmd}}i __zoxide_zi
-
-Set-Alias {{cmd}}a __zoxide_za
-
-Set-Alias {{cmd}}q __zoxide_zq
-Set-Alias {{cmd}}qi __zoxide_zqi
-
-Set-Alias {{cmd}}r __zoxide_zr
-Set-Alias {{cmd}}ri __zoxide_zri
 
 {%- when None %}
 {{ NOT_CONFIGURED }}

--- a/templates/xonsh.txt
+++ b/templates/xonsh.txt
@@ -133,46 +133,6 @@ def __zoxide_zi(args: List[str]):
     __zoxide_cd(__zoxide_result)
 
 
-def __zoxide_za(args: List[str]):
-    """Add a new entry to the database."""
-    try:
-        subprocess.run(["zoxide", "add"] + args, check=True)
-    except CalledProcessError as exc:
-        raise ZoxideSilentException from exc
-
-
-def __zoxide_zq(args: List[str]):
-    """Query an entry from the database using only keywords."""
-    try:
-        subprocess.run(["zoxide", "query"] + args, check=True)
-    except CalledProcessError as exc:
-        raise ZoxideSilentException from exc
-
-
-def __zoxide_zqi(args: List[str]):
-    """Query an entry from the database using interactive selection."""
-    try:
-        subprocess.run(["zoxide", "query", "-i"] + args, check=True)
-    except CalledProcessError as exc:
-        raise ZoxideSilentException from exc
-
-
-def __zoxide_zr(args: List[str]):
-    """Remove an entry from the database using the exact path."""
-    try:
-        subprocess.run(["zoxide", "remove"] + args, check=True)
-    except CalledProcessError as exc:
-        raise ZoxideSilentException from exc
-
-
-def __zoxide_zri(args: List[str]):
-    """Remove an entry from the database using interactive selection."""
-    try:
-        subprocess.run(["zoxide", "remove", "-i"] + args, check=True)
-    except CalledProcessError as exc:
-        raise ZoxideSilentException from exc
-
-
 {{ SECTION }}
 # Convenient aliases for zoxide. Disable these using --no-aliases.
 #
@@ -182,11 +142,6 @@ def __zoxide_zri(args: List[str]):
 
 aliases["{{cmd}}"] = __zoxide_z
 aliases["{{cmd}}i"] = __zoxide_zi
-aliases["{{cmd}}a"] = __zoxide_za
-aliases["{{cmd}}q"] = __zoxide_zq
-aliases["{{cmd}}qi"] = __zoxide_zqi
-aliases["{{cmd}}r"] = __zoxide_zr
-aliases["{{cmd}}ri"] = __zoxide_zri
 
 {%- when None %}
 {{ NOT_CONFIGURED }}

--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -71,31 +71,6 @@ function __zoxide_zi() {
     __zoxide_result="$(zoxide query -i -- "$@")" && __zoxide_cd "$__zoxide_result"
 }
 
-# Add a new entry to the database.
-function __zoxide_za() {
-    zoxide add "$@"
-}
-
-# Query an entry from the database using only keywords.
-function __zoxide_zq() {
-    zoxide query "$@"
-}
-
-# Query an entry from the database using interactive selection.
-function __zoxide_zqi() {
-    zoxide query -i "$@"
-}
-
-# Remove an entry from the database using the exact path.
-function __zoxide_zr() {
-    zoxide remove "$@"
-}
-
-# Remove an entry from the database using interactive selection.
-function __zoxide_zri() {
-    zoxide remove -i "$@"
-}
-
 {{ SECTION }}
 # Convenient aliases for zoxide. Disable these using --no-aliases.
 #
@@ -118,31 +93,6 @@ function {{cmd}}() {
 __zoxide_unset '{{cmd}}i'
 function {{cmd}}i() {
     __zoxide_zi "$@"
-}
-
-__zoxide_unset '{{cmd}}a'
-function {{cmd}}a() {
-    __zoxide_za "$@"
-}
-
-__zoxide_unset '{{cmd}}q'
-function {{cmd}}q() {
-    __zoxide_zq "$@"
-}
-
-__zoxide_unset '{{cmd}}qi'
-function {{cmd}}qi() {
-    __zoxide_zqi "$@"
-}
-
-__zoxide_unset '{{cmd}}r'
-function {{cmd}}r() {
-    __zoxide_zr "$@"
-}
-
-__zoxide_unset '{{cmd}}ri'
-function {{cmd}}ri() {
-    __zoxide_zri "$@"
 }
 
 {%- when None %}


### PR DESCRIPTION
A lot of the aliases defined by zoxide are used very rarely:

- `za`
- `zq`
- `zqi`
- `zr`
- `zri`

Moreover, they contain no special logic and are very easy to redefine:

- `alias za="zoxide add"`
- `alias zq="zoxide query"`
- `alias zqi="zoxide query -i"`
- `alias zr="zoxide remove"`
- `alias zri="zoxide remove -i"`

For that reason, such aliases are better off being left to the user to define as desired. This PR removes these aliases from zoxide.