### PR TITLE
add armv7/aarch64 support to installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,6 +33,9 @@ install() {
 		_cputype="x86_64"
 		_clibtype="musl"
 		;;
+	armv7 | aarch64)
+		_clibtype="musl"
+		;;
 	*)
 		warning "No binaries are available for your CPU architecture ($_cputype)"
 		_clibtype="gnu"


### PR DESCRIPTION
This works on aarch64 for me, but I don't currently have an armv7 host to test.
