### PR TITLE
Prevent endless recusion with alias cd on fish

### DIFF
--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -5,6 +5,21 @@
 # Utility functions for zoxide.
 #
 
+# provide a custom __fish_cd function that is either a copy of the default fish 
+# cd wrapper function, or an alias for the `builtin cd` to prevent recursively 
+# calling cd when using `alias cd=z`.
+#
+# only create the function `__fish_cd` if it doesn't yet exist
+if ! functions -q __fish_cd
+    if functions -q cd
+        # use the fish wrapper function for __fish_cd if it exists
+        functions -c cd __fish_cd
+    else
+        # use `builtin cd` as fallback if the cd wrapper function does not exist
+        alias __fish_cd="builtin cd"
+    end
+end
+
 # pwd based on the value of _ZO_RESOLVE_SYMLINKS.
 function __zoxide_pwd
 {%- if resolve_symlinks %}
@@ -18,8 +33,9 @@ end
 function __zoxide_cd
 {#- We can't use `builtin cd` over here, because fish wraps its builtin cd with
   a function that adds extra features (such as `cd -`). Using the builtin
-  would make those features stop working. #}
-    cd $argv
+  would make those features stop working. Instead use a custom function that is 
+  either a copy of the cd function or an alias for `builtin cd` as fallback #}
+    __fish_cd $argv
 {%- if echo %}
     and __zoxide_pwd
 {%- endif %}

--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -5,19 +5,11 @@
 # Utility functions for zoxide.
 #
 
-# provide a custom __fish_cd function that is either a copy of the default fish 
-# cd wrapper function, or an alias for the `builtin cd` to prevent recursively 
-# calling cd when using `alias cd=z`.
-#
-# only create the function `__fish_cd` if it doesn't yet exist
-if ! functions -q __fish_cd
-    if functions -q cd
-        # use the fish wrapper function for __fish_cd if it exists
-        functions -c cd __fish_cd
-    else
-        # use `builtin cd` as fallback if the cd wrapper function does not exist
-        alias __fish_cd="builtin cd"
-    end
+# Remove definitions.
+function __zoxide_unset
+    set --erase $argv >/dev/null 2>&1
+    abbr --erase $argv >/dev/null 2>&1
+    builtin functions --erase $argv >/dev/null 2>&1
 end
 
 # pwd based on the value of _ZO_RESOLVE_SYMLINKS.
@@ -29,13 +21,18 @@ function __zoxide_pwd
 {%- endif %}
 end
 
+# A copy of fish's internal cd function. This makes it possible to use
+# `alias cd=z` without causing an infinite loop.
+__zoxide_unset __zoxide_cd_internal
+if builtin functions -q cd
+    builtin functions -c cd __zoxide_cd_internal
+else
+    alias __zoxide_cd_internal="builtin cd"
+end
+
 # cd + custom logic based on the value of _ZO_ECHO.
 function __zoxide_cd
-{#- We can't use `builtin cd` over here, because fish wraps its builtin cd with
-  a function that adds extra features (such as `cd -`). Using the builtin
-  would make those features stop working. Instead use a custom function that is 
-  either a copy of the cd function or an alias for `builtin cd` as fallback #}
-    __fish_cd $argv
+    __zoxide_cd_internal $argv
 {%- if echo %}
     and __zoxide_pwd
 {%- endif %}
@@ -96,22 +93,11 @@ end
 {%- match cmd %}
 {%- when Some with (cmd) %}
 
-# Remove definitions.
-function __zoxide_unset
-    set --erase $argv >/dev/null 2>&1
-    abbr --erase $argv >/dev/null 2>&1
-    builtin functions --erase $argv >/dev/null 2>&1
-end
-
 __zoxide_unset {{cmd}}
-function {{cmd}}
-    __zoxide_z $argv
-end
+alias {{cmd}}="__zoxide_z"
 
 __zoxide_unset {{cmd}}i
-function {{cmd}}i
-    __zoxide_zi $argv
-end
+alias {{cmd}}i="__zoxide_zi"
 
 {%- when None %}
 


### PR DESCRIPTION
This is a fix for the endless recursion on fish: fixes #145

- Create a custom __fish_cd function for use in __zoxide_cd.
- The __fish_cd function is set to be either a copy of the fish cd
  wrapper function, or an alias for `builtin cd` as fallback if the
  wrapper function does not exist for some reason.
- This prevents an endless recusion when using `alias cd=z` that would
  occur because __zoxide_cd would call the `cd` alias which would in
  turn call `z` and so on.