### PR TITLE
Support Fish's private mode

### DIFF
--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -48,8 +48,8 @@ if test "$__zoxide_hooked" != 1
 {%- when InitHook::Pwd %}
     function __zoxide_hook --on-variable PWD
 {%- endmatch %}
-        set -q fish_private_mode
-        or command zoxide add -- (__zoxide_pwd)
+        test -z "$fish_private_mode"
+        and command zoxide add -- (__zoxide_pwd)
     end
 end
 

--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -48,7 +48,8 @@ if test "$__zoxide_hooked" != 1
 {%- when InitHook::Pwd %}
     function __zoxide_hook --on-variable PWD
 {%- endmatch %}
-        command zoxide add -- (__zoxide_pwd)
+        set -q fish_private_mode
+        or command zoxide add -- (__zoxide_pwd)
     end
 end
 


### PR DESCRIPTION
See fish docs: https://fishshell.com/docs/current/#private-mode

In this mode, fish will not record any command history. Some other projects also respect this config, for example [Fish port of z](https://github.com/jethrokuan/z/pull/98). I think it's a nice addition to zoxide! 