### PR TITLE
Improve Fish's completions

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,5 +1,14 @@
 use crate::app::InitHook;
 
+const FZF_COMPLETE_OPTS: &str = "\
+    --bind=ctrl-z:ignore \
+    --exit-0 \
+    --height=35% \
+    --inline-info \
+    --no-sort \
+    --reverse \
+    --select-1";
+
 #[derive(Debug, Eq, PartialEq)]
 pub struct Opts<'a> {
     pub cmd: Option<&'a str>,

--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -122,15 +122,7 @@ if [[ :"${SHELLOPTS}": =~ :(vi|emacs): ]] && [ "${TERM}" != 'dumb' ]; then
 
         if [[ ${query} == *"${trigger}" ]]; then
             query="${query:0:$(({{ "${#query} - ${#trigger}" }}))}"
-            COMPREPLY=("$(_ZO_FZF_OPTS="\
-                --bind=ctrl-z:ignore \
-                --exit-0 \
-                --height=35% \
-                --inline-info \
-                --no-sort \
-                --reverse \
-                --select-1 \
-                " zoxide query -i -- "${query}")")
+            COMPREPLY=("$(_ZO_FZF_OPTS='{{ crate::shell::FZF_COMPLETE_OPTS }}' zoxide query -i -- "${query}")")
             [[ $? -eq 130 ]] && COMPREPLY=("${query}")
             \builtin printf '\e[5n'
         else

--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -20,7 +20,7 @@ if ! builtin functions -q __zoxide_cd_internal
     if builtin functions -q cd
         builtin functions -c cd __zoxide_cd_internal
     else
-        alias __zoxide_cd_internal="builtin cd"
+        alias __zoxide_cd_internal='builtin cd'
     end
 end
 
@@ -65,14 +65,42 @@ function __zoxide_z
         __zoxide_cd $HOME
     else if test "$argv" = -
         __zoxide_cd -
-    else if begin
-            test $argc -eq 1; and test -d $argv[1]
-        end
+    else if test $argc -eq 1 -a -d $argv[1]
         __zoxide_cd $argv[1]
     else
         set -l result (command zoxide query --exclude (__zoxide_pwd) -- $argv)
         and __zoxide_cd $result
     end
+end
+
+# Completions for `z`.
+function __zoxide_z_complete
+    set -l line (commandline -op)
+    set -l trigger '**'
+    set -l trigger_length (string length $trigger)
+
+    set -l interactive 0
+    if test (string sub -s "-$trigger_length" $line[-1]) = $trigger
+        set line[-1] (string sub -e "-$trigger_length" $line[-1])
+        set interactive 1
+    end
+
+    set -l query $line[2..-1]
+    if test $interactive -eq 0 -a (count $query) -le 1
+        __fish_complete_directories "$query" ''
+        return
+    end
+
+    set -l result (_ZO_FZF_OPTS='{{ crate::shell::FZF_COMPLETE_OPTS }}' zoxide query -i -- $query)
+    set -l exit $status
+    if test $exit -ne 0
+        test $exit -eq 130
+        and commandline -p "$line"
+        return
+    end
+
+    set -l cmd $line[1]
+    commandline -p "$cmd "(string escape $result)
 end
 
 # Jump to a directory using interactive search.
@@ -96,14 +124,11 @@ function __zoxide_unset
 end
 
 __zoxide_unset {{cmd}}
-alias {{cmd}}="__zoxide_z"
-
-# Add completions.
-complete -c {{cmd}} -f -a '(__fish_complete_directories (commandline -t) "")'
-complete -c {{cmd}} -n "test -n (commandline -t)" -a "(zoxide query -l -- (commandline -t))" -k
+alias {{cmd}}=__zoxide_z
+complete -c {{cmd}} -f -a '(__zoxide_z_complete)'
 
 __zoxide_unset {{cmd}}i
-alias {{cmd}}i="__zoxide_zi"
+alias {{cmd}}i=__zoxide_zi
 
 {%- when None %}
 

--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -98,6 +98,10 @@ end
 __zoxide_unset {{cmd}}
 alias {{cmd}}="__zoxide_z"
 
+# Add completions.
+complete -c {{cmd}} -f -a '(__fish_complete_directories (commandline -t) "")'
+complete -c {{cmd}} -n "test -n (commandline -t)" -a "(zoxide query -l -- (commandline -t))" -k
+
 __zoxide_unset {{cmd}}i
 alias {{cmd}}i="__zoxide_zi"
 

--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -75,10 +75,10 @@ end
 
 # Completions for `z`.
 function __zoxide_z_complete
-    set -l line (commandline -op)
     set -l trigger '**'
     set -l trigger_length (string length $trigger)
 
+    set -l line (commandline -op)
     set -l interactive 0
     if test (string sub -s "-$trigger_length" $line[-1]) = $trigger
         set line[-1] (string sub -e "-$trigger_length" $line[-1])
@@ -86,11 +86,10 @@ function __zoxide_z_complete
     end
 
     set -l query $line[2..-1]
-    if test $interactive -eq 0 -a (count $query) -le 1
+    if test $interactive -eq 0 -a (count (commandline -cop)) -le 1
         __fish_complete_directories "$query" ''
         return
     end
-
     set -l result (_ZO_FZF_OPTS='{{ crate::shell::FZF_COMPLETE_OPTS }}' zoxide query -i -- $query)
     set -l exit $status
     if test $exit -ne 0


### PR DESCRIPTION
This PR brings two improvements to Fish's completions, when completing `{{cmd}}`:
- Let Fish only complete directories and excludes files
- If there is no match in the current directory, Fish will query zoxide with current token and serve them as completions:

  ![image](https://user-images.githubusercontent.com/44045911/118400631-04180f00-b695-11eb-9095-3b6758a447f6.png)

  This is approximately the same as using `zoxide query -i <current token>`, but more integrated with Fish.

Let me know if you have any suggestion over these two changes.