### PR TITLE
Add Chocolatey installation reference for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ copy it to your `$PATH`.
 | Repository   | Instructions           |
 | ------------ | ---------------------- |
 | [crates.io]  | `cargo install zoxide` |
-| [Scoop]      | `scoop install zoxide` |
 | [Chocolatey] | `choco install zoxide` |
+| [Scoop]      | `scoop install zoxide` |
 
 #### On BSD
 

--- a/README.md
+++ b/README.md
@@ -63,10 +63,11 @@ copy it to your `$PATH`.
 
 #### On Windows
 
-| Repository  | Instructions           |
-| ----------- | ---------------------- |
-| [crates.io] | `cargo install zoxide` |
-| [Scoop]     | `scoop install zoxide` |
+| Repository   | Instructions           |
+| ------------ | ---------------------- |
+| [crates.io]  | `cargo install zoxide` |
+| [Scoop]      | `scoop install zoxide` |
+| [Chocolatey] | `choco install zoxide` |
 
 #### On BSD
 
@@ -241,6 +242,7 @@ Be sure to set these before calling `zoxide init`.
 [algorithm-matching]: https://github.com/ajeetdsouza/zoxide/wiki/Algorithm#matching
 [alpine linux packages]: https://pkgs.alpinelinux.org/packages?name=zoxide
 [aur]: https://aur.archlinux.org/packages/zoxide-bin
+[chocolatey]: https://community.chocolatey.org/packages/zoxide
 [copr]: https://copr.fedorainfracloud.org/coprs/atim/zoxide/
 [crates.io-badge]: https://img.shields.io/crates/v/zoxide
 [crates.io]: https://crates.io/crates/zoxide


### PR DESCRIPTION
I have recently started to maintain a [Chocolatey package](https://community.chocolatey.org/packages/zoxide) of zoxide and it would be great to add it here.