### PR TITLE
Add "matching" to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,21 @@ Be sure to set these before calling `zoxide init`.
   - When set to `1`, `z` will resolve symlinks before adding directories to the
     database.
 
+## Matching
+
+zoxide uses a simple, predictable algorithm for resolving queries:
+
+* All matching is case-insensitive.  
+    `zoxide query foo` matches `/foo` as well as `/FOO`.
+* All terms must be present (including slashes) within the path, in order.  
+    `zoxide query fo ba` matches `/foo/bar`, but not `/bar/foo`.  
+    `zoxide query fo / ba` matches `/foo/bar`, but not `/foobar`.
+* The last component of the last keyword must match the last component of the path.  
+    `zoxide query bar` matches `/foo/bar`, but not `/bar/foo`.  
+    `zoxide query foo/bar` (last component: `bar`) matches `/foo/bar`, but not `/foo/bar/baz`.
+* The path must exist. Deleted directories are filtered out.  
+* Matches are returned in descending order of **FRECENCY**.
+
 ## Third-party integrations
 
 - [`nnn`][nnn] is a terminal file manager. You can use `zoxide` for navigation

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ zoxide uses a simple, predictable algorithm for resolving queries:
   supports `zoxide` out of the box.
 
 [algorithm-aging]: https://github.com/ajeetdsouza/zoxide/wiki/Algorithm#aging
-[algorithm-matching]: https://github.com/ajeetdsouza/zoxide/wiki/Algorithm#matching
+[algorithm-matching]: #matching
 [alpine linux packages]: https://pkgs.alpinelinux.org/packages?name=zoxide
 [aur]: https://aur.archlinux.org/packages/zoxide-bin
 [chocolatey]: https://community.chocolatey.org/packages/zoxide


### PR DESCRIPTION
README was linking to #matching but was not defined.
Adapt content from man-page to README.