### PR TITLE
Use single underscore for fish function/variables

### DIFF
--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -6,7 +6,7 @@
 #
 
 # pwd based on the value of _ZO_RESOLVE_SYMLINKS.
-function __zoxide_pwd
+function _zoxide_pwd
 {%- if resolve_symlinks %}
     builtin pwd -P
 {%- else %}
@@ -16,19 +16,19 @@ end
 
 # A copy of fish's internal cd function. This makes it possible to use
 # `alias cd=z` without causing an infinite loop.
-if ! builtin functions -q __zoxide_cd_internal
+if ! builtin functions -q _zoxide_cd_internal
     if builtin functions -q cd
-        builtin functions -c cd __zoxide_cd_internal
+        builtin functions -c cd _zoxide_cd_internal
     else
-        alias __zoxide_cd_internal="builtin cd"
+        alias _zoxide_cd_internal="builtin cd"
     end
 end
 
 # cd + custom logic based on the value of _ZO_ECHO.
-function __zoxide_cd
-    __zoxide_cd_internal $argv
+function _zoxide_cd
+    _zoxide_cd_internal $argv
 {%- if echo %}
-    and __zoxide_pwd
+    and _zoxide_pwd
 {%- endif %}
     and builtin commandline -f repaint
 end
@@ -38,18 +38,18 @@ end
 #
 
 # Initialize hook to add new entries to the database.
-if test "$__zoxide_hooked" != 1
-    set __zoxide_hooked 1
+if test "$_zoxide_hooked" != 1
+    set _zoxide_hooked 1
 {%- match hook %}
 {%- when InitHook::None %}
-    function __zoxide_hook
+    function _zoxide_hook
 {%- when InitHook::Prompt %}
-    function __zoxide_hook --on-event fish_prompt
+    function _zoxide_hook --on-event fish_prompt
 {%- when InitHook::Pwd %}
-    function __zoxide_hook --on-variable PWD
+    function _zoxide_hook --on-variable PWD
 {%- endmatch %}
         test -z "$fish_private_mode"
-        and command zoxide add -- (__zoxide_pwd)
+        and command zoxide add -- (_zoxide_pwd)
     end
 end
 
@@ -59,26 +59,26 @@ end
 #
 
 # Jump to a directory using only keywords.
-function __zoxide_z
+function _zoxide_z
     set argc (count $argv)
     if test $argc -eq 0
-        __zoxide_cd $HOME
+        _zoxide_cd $HOME
     else if test "$argv" = -
-        __zoxide_cd -
+        _zoxide_cd -
     else if begin
             test $argc -eq 1; and test -d $argv[1]
         end
-        __zoxide_cd $argv[1]
+        _zoxide_cd $argv[1]
     else
-        set -l __zoxide_result (command zoxide query --exclude (__zoxide_pwd) -- $argv)
-        and __zoxide_cd $__zoxide_result
+        set -l _zoxide_result (command zoxide query --exclude (_zoxide_pwd) -- $argv)
+        and _zoxide_cd $_zoxide_result
     end
 end
 
 # Jump to a directory using interactive search.
-function __zoxide_zi
-    set -l __zoxide_result (command zoxide query -i -- $argv)
-    and __zoxide_cd $__zoxide_result
+function _zoxide_zi
+    set -l _zoxide_result (command zoxide query -i -- $argv)
+    and _zoxide_cd $_zoxide_result
 end
 
 {{ section }}
@@ -89,17 +89,17 @@ end
 {%- when Some with (cmd) %}
 
 # Remove definitions.
-function __zoxide_unset
+function _zoxide_unset
     set --erase $argv >/dev/null 2>&1
     abbr --erase $argv >/dev/null 2>&1
     builtin functions --erase $argv >/dev/null 2>&1
 end
 
-__zoxide_unset {{cmd}}
-alias {{cmd}}="__zoxide_z"
+_zoxide_unset {{cmd}}
+alias {{cmd}}="_zoxide_z"
 
-__zoxide_unset {{cmd}}i
-alias {{cmd}}i="__zoxide_zi"
+_zoxide_unset {{cmd}}i
+alias {{cmd}}i="_zoxide_zi"
 
 {%- when None %}
 


### PR DESCRIPTION
Here is a little background (though it's 4 years ago): https://gitter.im/fish-shell/fish-shell?at=5730b1bcf16c08510662085b

This is an opinionated thing and it may break some advanced user's setup, but IMO it's worth it to be consistent with most Fish plugins out there.

Fish itself only uses two underscores for "private" functions (except for `_validate_int`, which is being tackled with fish-shell/fish-shell#8168). It's nice to be able to distinguish them with others.