### PR TITLE
use env macro over runtime in build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 use std::{env, io};
 
 fn main() {
-    let pkg_version = env::var("CARGO_PKG_VERSION").unwrap();
+    let pkg_version = env!("CARGO_PKG_VERSION");
     let version = match env::var_os("PROFILE") {
         Some(profile) if profile == "release" => format!("v{}", pkg_version),
         _ => git_version().unwrap_or_else(|| format!("v{}-unknown", pkg_version)),
@@ -11,6 +11,7 @@ fn main() {
 
     // Since we are generating completions in the package directory, we need to set this so that
     // Cargo doesn't rebuild every time.
+    println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=src");
     println!("cargo:rerun-if-changed=templates");
     println!("cargo:rerun-if-changed=tests");
@@ -19,7 +20,7 @@ fn main() {
 }
 
 fn git_version() -> Option<String> {
-    let dir = env::var("CARGO_MANIFEST_DIR").ok()?;
+    let dir = env!("CARGO_MANIFEST_DIR");
     let mut git = Command::new("git");
     git.args(&["-C", &dir, "describe", "--tags", "--broken"]);
 
@@ -40,7 +41,7 @@ fn generate_completions() -> io::Result<()> {
     use clap_generate::generators::{Bash, Elvish, Fish, PowerShell, Zsh};
 
     let app = &mut App::into_app();
-    let bin_name = &env::var("CARGO_PKG_NAME").unwrap();
+    let bin_name = env!("CARGO_PKG_NAME");
     let out_dir = "contrib/completions";
 
     generate_to::<Bash, _, _>(app, bin_name, out_dir)?;


### PR DESCRIPTION
env!() fails on compile time while env::var fails on executing the build script.

Also rerun the build when the build.rs changed.