### PR TITLE
Addition of Minimum Supported Version of Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zoxide"
 version = "0.7.9"
+rust-version = "1.56"
 authors = ["Ajeet D'Souza <98ajeet@gmail.com>"]
 edition = "2018"
 description = "A smarter cd command for your terminal"
@@ -29,7 +30,7 @@ tempfile = "3.1.0"
 
 [target.'cfg(windows)'.dependencies]
 rand = { version = "0.8.4", features = [
-    "getrandom",
+  "getrandom",
     "small_rng",
 ], default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "zoxide"
-version = "0.7.9"
-rust-version = "1.56"
 authors = ["Ajeet D'Souza <98ajeet@gmail.com>"]
-edition = "2018"
-description = "A smarter cd command for your terminal"
-repository = "https://github.com/ajeetdsouza/zoxide"
-license = "MIT"
-keywords = ["cli"]
 categories = ["command-line-utilities", "filesystem"]
+description = "A smarter cd command for your terminal"
+edition = "2018"
+keywords = ["cli"]
+license = "MIT"
+name = "zoxide"
+repository = "https://github.com/ajeetdsouza/zoxide"
+rust-version = "1.56"
+version = "0.7.9"
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -31,7 +31,7 @@ tempfile = "3.1.0"
 [target.'cfg(windows)'.dependencies]
 rand = { version = "0.8.4", features = [
   "getrandom",
-    "small_rng",
+  "small_rng",
 ], default-features = false }
 
 [build-dependencies]


### PR DESCRIPTION
This PR simply adds rust-version in Cargo.toml

### Complete MSRV table for zoxide
| zoxide  |  MSRV  |
| :-----: | :----: |
|  0.1.0  | 1.46.0 |
|  0.1.1  | 1.46.0 |
|  0.2.0  | 1.34.2 |
|  0.2.1  | 1.34.2 |
|  0.2.2  | 1.34.2 |
|  0.3.0  | 1.39.0 |
|  0.3.1  | 1.39.0 |
|  0.4.0  | 1.39.0 |
|  0.4.1  | 1.39.0 |
|  0.4.2  | 1.39.0 |
|  0.4.3  | 1.39.0 |
|  0.5.0  | 1.46.0 |
|  0.6.0  | 1.43.1 |
|  0.7.0  | 1.43.1 |
|  0.7.1  | 1.43.1 |
|  0.7.2  | 1.43.1 |
|  0.7.3  | 1.43.1 |
|  0.7.4  | 1.54.0 |
|  0.7.5  | 1.54.0 |
|  0.7.6  | 1.54.0 |
|  0.7.7  | 1.54.0 |
|  0.7.8  | 1.54.0 |
|  0.7.9  | 1.54.0 |

### References
1. https://github.com/foresterre/cargo-msrv
2. https://github.com/foresterre/cargo-msrv/blob/main/Cargo.toml#L11 (package.metadata)