### PR TITLE
fix: don't error during __zoxide_unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - PowerShell: use global scope for aliases.
+- Zsh: fix errors with `set -eu`.
 
 ## [0.7.9] - 2021-11-02
 

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -222,7 +222,7 @@ mod tests {
         let opts = Opts { cmd, hook, echo, resolve_symlinks };
         let source = Posix(&opts).render().unwrap();
 
-        let assert = Command::new("dash").args(&["-c", &source, "-e", "-u"]).assert().success().stderr("");
+        let assert = Command::new("dash").args(&["-e", "-u", "-c", &source]).assert().success().stderr("");
         if opts.hook != InitHook::Pwd {
             assert.stdout("");
         }
@@ -380,7 +380,7 @@ mod tests {
         let source = Zsh(&opts).render().unwrap();
 
         Command::new("zsh")
-            .args(&["-c", &source, "-e", "-u", "-o", "pipefail", "--no-globalrcs", "--no-rcs"])
+            .args(&["-e", "-u", "-o", "pipefail", "--no-globalrcs", "--no-rcs", "-c", &source])
             .assert()
             .success()
             .stdout("")

--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -86,8 +86,8 @@ function __zoxide_zi() {
 
 # Remove definitions.
 function __zoxide_unset() {
-    \builtin unalias "$@" &>/dev/null
-    \builtin unfunction "$@" &>/dev/null
+    \builtin unalias "$@" &>/dev/null || true
+    \builtin unfunction "$@" &>/dev/null || true
     \builtin unset "$@" &>/dev/null
 }
 

--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -35,11 +35,11 @@ function __zoxide_hook() {
 
 # Initialize hook.
 # shellcheck disable=SC2154
-if [[ ${precmd_functions[(Ie)__zoxide_hook]} -eq 0 ]] && [[ ${chpwd_functions[(Ie)__zoxide_hook]} -eq 0 ]]; then
+if [[ ${precmd_functions[(Ie)__zoxide_hook]:-} -eq 0 ]] && [[ ${chpwd_functions[(Ie)__zoxide_hook]:-} -eq 0 ]]; then
 {%- if hook == InitHook::Prompt %}
     precmd_functions+=(__zoxide_hook)
 {%- else if hook == InitHook::Pwd %}
-    chpwd_functions=("${chpwd_functions[@]}" "__zoxide_hook")
+    chpwd_functions+=(__zoxide_hook)
 {%- endif %}
 fi
 


### PR DESCRIPTION
If `set -e` is enabled then `eval $(zoxide init zsh)` errors when the alias aren't already set (eg: in a fresh shell). This fixes that.  