### PR TITLE
Add path escapes for powershell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PowerShell: use global scope for aliases.
 - Zsh: fix errors with `set -eu`.
 - Fzf: handle early selection.
+- PowerShell: correctly handle escape characters in paths.
 
 ## [0.7.9] - 2021-11-02
 

--- a/templates/powershell.txt
+++ b/templates/powershell.txt
@@ -7,17 +7,19 @@
 
 # pwd based on zoxide's format.
 function __zoxide_pwd {
-    $__zoxide_pwd = Get-Location
-    if ($__zoxide_pwd.Provider.Name -eq "FileSystem") {
-        $__zoxide_pwd.ProviderPath
+    $cwd = Get-Location
+    if ($cwd.Provider.Name -eq "FileSystem") {
+        $cwd.ProviderPath
     }
 }
 
 # cd + custom logic based on the value of _ZO_ECHO.
 function __zoxide_cd($dir) {
-    Set-Location -LiteralPath $dir -ErrorAction Stop
 {%- if echo %}
-    $(Get-Location).Path
+    $dir = Set-Location -LiteralPath $dir -Passthru -ErrorAction Stop
+    Write-Output $dir.Path
+{%- else %}
+    Set-Location -LiteralPath $dir -ErrorAction Stop
 {%- endif %}
 }
 

--- a/templates/powershell.txt
+++ b/templates/powershell.txt
@@ -15,7 +15,7 @@ function __zoxide_pwd {
 
 # cd + custom logic based on the value of _ZO_ECHO.
 function __zoxide_cd($dir) {
-    Set-Location ([Management.Automation.WildcardPattern]::escape($dir)) -ea Stop
+    Set-Location -LiteralPath $dir -ErrorAction Stop
 {%- if echo %}
     $(Get-Location).Path
 {%- endif %}

--- a/templates/powershell.txt
+++ b/templates/powershell.txt
@@ -15,7 +15,7 @@ function __zoxide_pwd {
 
 # cd + custom logic based on the value of _ZO_ECHO.
 function __zoxide_cd($dir) {
-    Set-Location $dir -ea Stop
+    Set-Location ([Management.Automation.WildcardPattern]::escape($dir)) -ea Stop
 {%- if echo %}
     $(Get-Location).Path
 {%- endif %}


### PR DESCRIPTION
Fixes #312

Adds path escape to `Set-Location` call, fixing compatibility with paths containing special characters like square brackets.