### PR TITLE
Document that webinstall.dev/zoxide installs more than zoxide

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To install zoxide, run this command in your terminal:
 curl -sS https://webinstall.dev/zoxide | bash
 ```
 
-Alternatively, you can use a package manager:
+The above installs `webi`, `pathman`, `envman`, and makes changes to your `~/.bashrc` and/or `~/.zshrc`. For a less intrusive option, use a package manager:
 
 | Distribution       | Repository              | Instructions                                                                                   |
 | ------------------ | ----------------------- | ---------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Resolves #318

I was not pleased when I blindly ran `webinstall`. Had I used more braincells I would've elected to use a package manager.