### PR TITLE
Improve fzf readability on narrow screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - manpages: moved to `man/man1/*.1`.
+- fzf: added `--keep-right` option by default, upgraded minimum version to v0.21.0.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
+checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
 name = "askama"
@@ -123,9 +123,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.10"
+version = "3.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a30c3bf9ff12dfe5dae53f0a96e0febcd18420d1c0e7fad77796d9d5c4b5375"
+checksum = "08799f92c961c7a1cf0cc398a9073da99e21ce388b46372c37f3191f2f3eed3e"
 dependencies = [
  "atty",
  "bitflags",
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d044e9db8cd0f68191becdeb5246b7462e4cf0c069b19ae00d1bf3fa9889498d"
+checksum = "be4dabb7e2f006497e1da045feaa512acf0686f76b68d94925da2d9422dcb521"
 dependencies = [
  "clap",
 ]
@@ -159,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.6"
+version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+checksum = "0fd2078197a22f338bd4fbf7d6387eb6f0d6a3c69e6cbc09f5c93e97321fd92a"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -226,9 +226,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "fastrand"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
 ]
@@ -344,9 +344,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.113"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
 
 [[package]]
 name = "log"
@@ -475,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -590,18 +590,18 @@ checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -688,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]

--- a/README.md
+++ b/README.md
@@ -260,7 +260,8 @@ eval "$(zoxide init posix --hook prompt)"
 ### *Step 3: Install fzf (optional)*
 
 [fzf] is a command-line fuzzy finder, used by zoxide for interactive
-selection. It can be installed from [here][fzf-installation].
+selection. It can be installed from [here][fzf-installation]. zoxide supports
+fzf v0.21.0+.
 
 ### *Step 4: Import your data (optional)*
 

--- a/src/fzf.rs
+++ b/src/fzf.rs
@@ -26,7 +26,7 @@ impl Fzf {
                 "--bind=ctrl-z:ignore",
                 "--exit-0",
                 "--height=40%",
-                "--inline-info",
+                "--info=inline",
                 "--no-sort",
                 "--reverse",
                 "--select-1",

--- a/src/fzf.rs
+++ b/src/fzf.rs
@@ -23,14 +23,19 @@ impl Fzf {
             command.env("FZF_DEFAULT_OPTS", fzf_opts);
         } else {
             command.args(&[
-                "--bind=ctrl-z:ignore",
-                "--exit-0",
-                "--select-1",
+                // Search result
+                "--no-sort",
+                // Interface
+                "--keep-right",
+                // Layout
                 "--height=40%",
                 "--info=inline",
-                "--no-sort",
-                "--reverse",
-                "--keep-right"
+                "--layout=reverse",
+                // Scripting
+                "--exit-0",
+                "--select-1",
+                // Key/Event bindings
+                "--bind=ctrl-z:ignore",
             ]);
             if cfg!(unix) {
                 command.arg("--preview=ls -p {2..}");

--- a/src/fzf.rs
+++ b/src/fzf.rs
@@ -25,11 +25,11 @@ impl Fzf {
             command.args(&[
                 "--bind=ctrl-z:ignore",
                 "--exit-0",
+                "--select-1",
                 "--height=40%",
                 "--info=inline",
                 "--no-sort",
                 "--reverse",
-                "--select-1",
             ]);
             if cfg!(unix) {
                 command.arg("--preview=ls -p {2..}");

--- a/src/fzf.rs
+++ b/src/fzf.rs
@@ -30,6 +30,7 @@ impl Fzf {
                 "--info=inline",
                 "--no-sort",
                 "--reverse",
+                "--keep-right"
             ]);
             if cfg!(unix) {
                 command.arg("--preview=ls -p {2..}");


### PR DESCRIPTION
[--keep-right] trims paths from the left/start, preventing long folder
chains from taking over the prompt and making the choice ambiguous:

Without it:
```
/long/folder/chain/with/same/prefi...
/long/folder/chain/with/same/prefi...
/long/folder/chain/with/same/prefi...
/long/folder/chain/with/same/prefi...
```

With it:
```
...der/chain/with/same/prefix/folder1
...der/chain/with/same/prefix/folder2
...der/chain/with/same/prefix/folder3
...der/chain/with/same/prefix/folder4
```

Thanks for taking the time to write this awesome utility!

[--keep-right]: https://www.mankier.com/1/fzf#--keep-right


