### PR TITLE
Fix Windows _ZO_DATA_DIR path in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ They must be set before `zoxide init` is called.
     | ----------- | ---------------------------------------- | ------------------------------------------ |
     | Linux / BSD | `$XDG_DATA_HOME` or `$HOME/.local/share` | `/home/alice/.local/share`                 |
     | macOS       | `$HOME/Library/Application Support`      | `/Users/Alice/Library/Application Support` |
-    | Windows     | `{FOLDERID_RoamingAppData}`              | `C:\Users\Alice\AppData\Roaming`           |
+    | Windows     | `%LOCALAPPDATA%`                         | `C:\Users\Alice\AppData\Local`             |
 - `_ZO_ECHO`
   - When set to 1, `z` will print the matched directory before navigating to
     it.

--- a/man/man1/zoxide.1
+++ b/man/man1/zoxide.1
@@ -65,7 +65,7 @@ T}
 \fB/Users/Alice/Library/Application Support\fR
 T}
     \fBWindows\fR|T{
-\fB{FOLDERID_RoamingAppData}\fR, eg. \fBC:\\Users\\Alice\\AppData\\Roaming\fR
+\fB%LOCALAPPDATA%\fR, eg. \fBC:\\Users\\Alice\\AppData\\Local\fR
 T}
 .TE
 .TP


### PR DESCRIPTION
`_ZO_DATA_DIR` in Windows is actually located at `%LOCALAPPDATA%`, not in `%APPDATA%`