### PR TITLE
Simplify fish init script

### DIFF
--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -102,20 +102,15 @@ end
 {%- match cmd %}
 {%- when Some with (cmd) %}
 
-# Remove definitions.
-function __zoxide_unset
-    set --erase $argv >/dev/null 2>&1
-    abbr --erase $argv >/dev/null 2>&1
-    builtin functions --erase $argv >/dev/null 2>&1
+function {{cmd}}
+    __zoxide_z $argv
 end
-
-__zoxide_unset {{cmd}}
-alias {{cmd}}=__zoxide_z
 complete -c {{cmd}} -e
 complete -c {{cmd}} -f -a '(__zoxide_z_complete)'
 
-__zoxide_unset {{cmd}}i
-alias {{cmd}}i=__zoxide_zi
+function {{cmd}}i
+    __zoxide_zi $argv
+end
 
 {%- when None %}
 

--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -105,12 +105,15 @@ end
 function {{cmd}}
     __zoxide_z $argv
 end
+abbr --erase {{cmd}}
 complete -c {{cmd}} -e
 complete -c {{cmd}} -f -a '(__zoxide_z_complete)'
 
 function {{cmd}}i
     __zoxide_zi $argv
 end
+abbr --erase {{cmd}}i
+complete -c {{cmd}}i -e
 
 {%- when None %}
 


### PR DESCRIPTION
- Remove usage of `__zoxide_unset`.
  - There is no need to remove namesake variables, which don't even make sense.
  - Similarly, no need to remove abbrs. Users should know better than to set an abbreviation with the same name.
  - New functions will discard old ones with the same name.

- Replace `alias` with idiomatic `function`.

  fish's [`alias`](https://fishshell.com/docs/current/cmds/alias.html) is simply a function wrapper and slower than defining functions directly.