### PR TITLE
switch elvish template to new try/catch syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # FIXME: Enable macos-latest when this is merged: https://nixpk.gs/pr-tracker.html?pr=163924
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bash/Zsh: rename `_z` completion function to avoid conflicts with other shell
   plugins.
 - Elvish: upgrade to new lambda syntax.
-- Fzf: added `--keep-right` option by default, upgraded minimum version to
-  v0.21.0.
+- Fzf: added `--keep-right` option by default, upgrade minimum supported version
+  to v0.21.0.
 - Bash: only enable completions on 4.4+.
 - Fzf: bypass `ls` alias in preview window.
 - Retain ownership of database file.
+- Elvish: upgrade to new try-catch syntax, upgrade minimum supported version to
+  v0.18.0.
 
 ## [0.8.0] - 2021-12-25
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,8 @@ eval "$(zoxide init zsh)"
 ```
 
 For completions to work, the above line must be added *after* `compinit` is
-called. You may have to rebuild your cache by running `rm ~/.zcompdump*; compinit`.
+called. You may have to rebuild your cache by running
+`rm ~/.zcompdump*; compinit`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Add this to your configuration (usually `~/.zshrc`):
 eval "$(zoxide init zsh)"
 ```
 
-For completions to work, the above line must be added _after_ `compinit` is
+For completions to work, the above line must be added *after* `compinit` is
 called. You may have to rebuild your cache by running `rm ~/.zcompdump*; compinit`.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Add this to your configuration (usually `~/.elvish/rc.elv`):
 eval (zoxide init elvish | slurp)
 ```
 
-Note: zoxide only supports elvish v0.16.0 and above.
+Note: zoxide only supports elvish v0.18.0 and above.
 
 </details>
 

--- a/man/man1/zoxide-init.1
+++ b/man/man1/zoxide-init.1
@@ -20,7 +20,7 @@ Add this to your configuration (usually \fB~/.elvish/rc.elv\fR):
     \fBeval $(zoxide init elvish | slurp)\fR
 .fi
 .sp
-Note: zoxide only supports elvish v0.16.0 and above.
+Note: zoxide only supports elvish v0.18.0 and above.
 .TP
 .B fish
 Add this to your configuration (usually \fB~/.config/fish/config.fish\fR):

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@ let
   rust = import (builtins.fetchTarball
     "https://github.com/oxalica/rust-overlay/archive/46d8d20fce510c6a25fa66f36e31f207f6ea49e4.tar.gz");
   pkgs = import (builtins.fetchTarball
-    "https://github.com/NixOS/nixpkgs/archive/fae46e66a5df220327b45e0d7c27c6961cf922ce.tar.gz") {
+    "https://github.com/NixOS/nixpkgs/archive/d19a9162c848517cfc9437f10945b736d718b948.tar.gz") {
       overlays = [ rust ];
     };
 in pkgs.mkShell {

--- a/templates/elvish.txt
+++ b/templates/elvish.txt
@@ -57,7 +57,7 @@ fn __zoxide_z {|@rest|
         var path
         try {
             set path = (zoxide query --exclude $pwd -- $@rest)
-        } except {
+        } catch {
         } else {
             __zoxide_cd $path
         }
@@ -70,7 +70,7 @@ fn __zoxide_zi {|@rest|
     var path
     try {
         set path = (zoxide query -i -- $@rest)
-    } except {
+    } catch {
     } else {
         __zoxide_cd $path
     }
@@ -116,4 +116,4 @@ set edit:completion:arg-completer[{{cmd}}] = $__zoxide_z_complete~
 #
 #   eval (zoxide init elvish | slurp)
 #
-# Note: zoxide only supports elvish v0.17.0 and above.
+# Note: zoxide only supports elvish v0.18.0 and above.


### PR DESCRIPTION
'except' has been deprecated and replaced by 'catch' in elvish 0.18, and will be removed in 0.19

see the relevant issue here: https://github.com/elves/elvish/issues/1497