### PR TITLE
fix: interactive completion for fish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fish: paths on Cygwin.
+- Bash/Fish/Posix/Zsh: paths on Cygwin.
 - Fish: completions not working on certain systems.
 
 ## [0.8.1] - 2021-04-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fish: fix paths on Cygwin.
+- Fish: paths on Cygwin.
+- Fish: completions not working on certain systems.
 
 ## [0.8.1] - 2021-04-23
 

--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -13,7 +13,7 @@ function __zoxide_pwd() {
     \builtin pwd -P
 {%- else %}
     \builtin pwd -L
-{%- endif %} || \builtin true
+{%- endif %}
 }
 
 # cd + custom logic based on the value of _ZO_ECHO.
@@ -34,6 +34,7 @@ function __zoxide_cd() {
 {%- if hook == InitHook::Prompt %}
 function __zoxide_hook() {
     \builtin local -r retval="$?"
+    # shellcheck disable=SC2312
     \command zoxide add -- "$(__zoxide_pwd)"
     return "${retval}"
 }
@@ -80,6 +81,7 @@ function __zoxide_z() {
         __zoxide_cd "{{ "${result:${#__zoxide_z_prefix}}" }}"
     else
         \builtin local result
+        # shellcheck disable=SC2312
         result="$(\command zoxide query --exclude "$(__zoxide_pwd)" -- "$@")" &&
             __zoxide_cd "${result}"
     fi
@@ -129,6 +131,7 @@ if [[ ${BASH_VERSINFO[0]:-0} -eq 4 && ${BASH_VERSINFO[1]:-0} -ge 4 || ${BASH_VER
         # If there is a space after the last word, use interactive selection.
         elif [[ -z ${COMP_WORDS[-1]} ]]; then
             \builtin local result
+            # shellcheck disable=SC2312
             result="$(\command zoxide query --exclude "$(__zoxide_pwd)" -i -- "{{ "${COMP_WORDS[@]:1:${#COMP_WORDS[@]}-2}" }}")" &&
                 COMPREPLY=("${__zoxide_z_prefix}${result@Q}")
             \builtin printf '\e[5n'

--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -13,7 +13,7 @@ function __zoxide_pwd() {
     \builtin pwd -P
 {%- else %}
     \builtin pwd -L
-{%- endif %}
+{%- endif %} || \builtin true
 }
 
 # cd + custom logic based on the value of _ZO_ECHO.
@@ -34,7 +34,7 @@ function __zoxide_cd() {
 {%- if hook == InitHook::Prompt %}
 function __zoxide_hook() {
     \builtin local -r retval="$?"
-    \command zoxide add -- "$(__zoxide_pwd || \builtin true)"
+    \command zoxide add -- "$(__zoxide_pwd)"
     return "${retval}"
 }
 {%- else if hook == InitHook::Pwd %}
@@ -80,7 +80,7 @@ function __zoxide_z() {
         __zoxide_cd "{{ "${result:${#__zoxide_z_prefix}}" }}"
     else
         \builtin local result
-        result="$(\command zoxide query --exclude "$(__zoxide_pwd || \builtin true)" -- "$@")" &&
+        result="$(\command zoxide query --exclude "$(__zoxide_pwd)" -- "$@")" &&
             __zoxide_cd "${result}"
     fi
 }
@@ -98,19 +98,12 @@ function __zoxide_zi() {
 {%- match cmd %}
 {%- when Some with (cmd) %}
 
-# Remove definitions.
-function __zoxide_unset() {
-    \builtin unset -f "$@" &>/dev/null
-    \builtin unset -v "$@" &>/dev/null
-    \builtin unalias "$@" &>/dev/null || \builtin :
-}
-
-__zoxide_unset {{cmd}}
+\builtin unalias {{cmd}} &>/dev/null || \builtin true
 function {{cmd}}() {
     __zoxide_z "$@"
 }
 
-__zoxide_unset {{cmd}}i
+\builtin unalias {{cmd}}i &>/dev/null || \builtin true
 function {{cmd}}i() {
     __zoxide_zi "$@"
 }
@@ -136,13 +129,14 @@ if [[ ${BASH_VERSINFO[0]:-0} -eq 4 && ${BASH_VERSINFO[1]:-0} -ge 4 || ${BASH_VER
         # If there is a space after the last word, use interactive selection.
         elif [[ -z ${COMP_WORDS[-1]} ]]; then
             \builtin local result
-            result="$(\command zoxide query -i -- "{{ "${COMP_WORDS[@]:1:${#COMP_WORDS[@]}-2}" }}")" &&
+            result="$(\command zoxide query --exclude "$(__zoxide_pwd)" -i -- "{{ "${COMP_WORDS[@]:1:${#COMP_WORDS[@]}-2}" }}")" &&
                 COMPREPLY=("${__zoxide_z_prefix}${result@Q}")
             \builtin printf '\e[5n'
         fi
     }
 
     \builtin complete -F __zoxide_z_complete -o nospace -- {{cmd}}
+    \builtin complete -r {{cmd}}i &>/dev/null || \builtin true
 fi
 
 {%- when None %}

--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -72,7 +72,12 @@ function __zoxide_z
     else if test $argc -eq 1 -a -d $argv[1]
         __zoxide_cd $argv[1]
     else
-        set -l result (command zoxide query --exclude (__zoxide_pwd) -- $argv)
+        if string match '*#*' $argv &>/dev/null
+            set target (string match '*#*' $argv | string replace \# '')
+        else
+            set target $argv
+        end
+        set -l result (command zoxide query --exclude (__zoxide_pwd) -- $target)
         and __zoxide_cd $result
     end
 end
@@ -89,7 +94,7 @@ function __zoxide_z_complete
         # If the last argument is empty, use interactive selection.
         set -l query $tokens[2..-1]
         set -l result (zoxide query -i -- $query)
-        and commandline --current-process "$tokens[1] "(string escape $result)
+        and echo \#(string escape $result)
         commandline --function repaint
     end
 end

--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -62,22 +62,23 @@ end
 # When using zoxide with --no-cmd, alias these internal functions as desired.
 #
 
+set __zoxide_z_prefix 'z#'
+
 # Jump to a directory using only keywords.
 function __zoxide_z
-    set argc (count $argv)
+    set -l argc (count $argv)
+    set -l completion_regex '^'(string escape --style=regex $__zoxide_z_prefix)'(.*)$'
+
     if test $argc -eq 0
         __zoxide_cd $HOME
     else if test "$argv" = -
         __zoxide_cd -
     else if test $argc -eq 1 -a -d $argv[1]
         __zoxide_cd $argv[1]
+    else if set -l result (string match --groups-only --regex $completion_regex $argv[-1])
+        __zoxide_cd $result
     else
-        if string match '*#*' $argv &>/dev/null
-            set target (string match '*#*' $argv | string replace \# '')
-        else
-            set target $argv
-        end
-        set -l result (command zoxide query --exclude (__zoxide_pwd) -- $target)
+        set -l result (command zoxide query --exclude (__zoxide_pwd) -- $argv)
         and __zoxide_cd $result
     end
 end
@@ -93,8 +94,8 @@ function __zoxide_z_complete
     else if test (count $tokens) -eq (count $curr_tokens)
         # If the last argument is empty, use interactive selection.
         set -l query $tokens[2..-1]
-        set -l result (zoxide query -i -- $query)
-        and echo \#(string escape $result)
+        set -l result (zoxide query --exclude (__zoxide_pwd) -i -- $query)
+        and echo $__zoxide_z_prefix$result
         commandline --function repaint
     end
 end
@@ -112,18 +113,18 @@ end
 {%- match cmd %}
 {%- when Some with (cmd) %}
 
+abbr --erase {{cmd}}
+complete -c {{cmd}} -e
 function {{cmd}}
     __zoxide_z $argv
 end
-abbr --erase {{cmd}}
-complete -c {{cmd}} -e
 complete -c {{cmd}} -f -a '(__zoxide_z_complete)'
 
+abbr --erase {{cmd}}i
+complete -c {{cmd}}i -e
 function {{cmd}}i
     __zoxide_zi $argv
 end
-abbr --erase {{cmd}}i
-complete -c {{cmd}}i -e
 
 {%- when None %}
 

--- a/templates/posix.txt
+++ b/templates/posix.txt
@@ -7,7 +7,9 @@
 
 # pwd based on the value of _ZO_RESOLVE_SYMLINKS.
 __zoxide_pwd() {
-{%- if resolve_symlinks %}
+{%- if cfg!(windows) %}
+    \command cygpath -w "$(\builtin pwd -P)"
+{%- else if resolve_symlinks %}
     \command pwd -P
 {%- else %}
     \command pwd -L
@@ -82,20 +84,12 @@ __zoxide_zi() {
 {%- match cmd %}
 {%- when Some with (cmd) %}
 
-# Remove definitions.
-__zoxide_unset() {
-    \command unset -f "$@" >/dev/null 2>&1
-    \command unset -v "$@" >/dev/null 2>&1
-    # shellcheck disable=SC1001
-    \command unalias "$@" >/dev/null 2>&1 || \:
-}
-
-__zoxide_unset '{{cmd}}'
+\command unalias {{cmd}} >/dev/null 2>&1 || \true
 {{cmd}}() {
     __zoxide_z "$@"
 }
 
-__zoxide_unset '{{cmd}}i'
+\command unalias {{cmd}}i >/dev/null 2>&1 || \true
 {{cmd}}i() {
     __zoxide_zi "$@"
 }

--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -13,7 +13,7 @@ function __zoxide_pwd() {
     \builtin pwd -P
 {%- else %}
     \builtin pwd -L
-{%- endif %}
+{%- endif %} || \builtin true
 }
 
 # cd + custom logic based on the value of _ZO_ECHO.
@@ -32,7 +32,7 @@ function __zoxide_cd() {
 {% else -%}
 # Hook to add new entries to the database.
 function __zoxide_hook() {
-    \command zoxide add -- "$(__zoxide_pwd || \builtin true)"
+    \command zoxide add -- "$(__zoxide_pwd)"
 }
 
 # Initialize hook.
@@ -74,7 +74,7 @@ function __zoxide_z() {
         __zoxide_cd "{{ "${result:${#__zoxide_z_prefix}}" }}"
     else
         \builtin local result
-        result="$(\command zoxide query --exclude "$(__zoxide_pwd || \builtin true)" -- "$@")" &&
+        result="$(\command zoxide query --exclude "$(__zoxide_pwd)" -- "$@")" &&
             __zoxide_cd "${result}"
     fi
 }
@@ -92,25 +92,17 @@ function __zoxide_zi() {
 {%- match cmd %}
 {%- when Some with (cmd) %}
 
-# Remove definitions.
-function __zoxide_unset() {
-    \builtin unalias "$@" &>/dev/null || \builtin true
-    \builtin unfunction "$@" &>/dev/null || \builtin true
-    \builtin unset "$@" &>/dev/null
-}
-
-__zoxide_unset {{cmd}}
+\builtin unalias {{cmd}} &>/dev/null || \builtin true
 function {{cmd}}() {
     __zoxide_z "$@"
 }
 
-__zoxide_unset {{cmd}}i
+\builtin unalias {{cmd}}i &>/dev/null || \builtin true
 function {{cmd}}i() {
     __zoxide_zi "$@"
 }
 
 if [[ -o zle ]]; then
-    __zoxide_unset __zoxide_z_complete
     function __zoxide_z_complete() {
         # Only show completions when the cursor is at the end of the line.
         # shellcheck disable=SC2154
@@ -121,7 +113,7 @@ if [[ -o zle ]]; then
         elif [[ "${words[-1]}" == '' ]]; then
             \builtin local result
             # shellcheck disable=SC2086
-            if result="$(\command zoxide query -i -- ${words[2,-1]})"; then
+            if result="$(\command zoxide query --exclude "$(__zoxide_pwd)" -i -- ${words[2,-1]})"; then
                 __zoxide_result="${result}"
             else
                 __zoxide_result=''
@@ -130,7 +122,6 @@ if [[ -o zle ]]; then
         fi
     }
 
-    __zoxide_unset __zoxide_z_complete_helper
     function __zoxide_z_complete_helper() {
         \builtin local result="${__zoxide_z_prefix}${__zoxide_result}"
         # shellcheck disable=SC2296
@@ -142,6 +133,7 @@ if [[ -o zle ]]; then
     \builtin bindkey "\e[0n" __zoxide_z_complete_helper
     if [[ "${+functions[compdef]}" -ne 0 ]]; then
         \compdef -d {{cmd}}
+        \compdef -d {{cmd}}i
         \compdef __zoxide_z_complete {{cmd}}
     fi
 fi

--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -13,7 +13,7 @@ function __zoxide_pwd() {
     \builtin pwd -P
 {%- else %}
     \builtin pwd -L
-{%- endif %} || \builtin true
+{%- endif %}
 }
 
 # cd + custom logic based on the value of _ZO_ECHO.
@@ -32,6 +32,7 @@ function __zoxide_cd() {
 {% else -%}
 # Hook to add new entries to the database.
 function __zoxide_hook() {
+    # shellcheck disable=SC2312
     \command zoxide add -- "$(__zoxide_pwd)"
 }
 
@@ -74,6 +75,7 @@ function __zoxide_z() {
         __zoxide_cd "{{ "${result:${#__zoxide_z_prefix}}" }}"
     else
         \builtin local result
+        # shellcheck disable=SC2312
         result="$(\command zoxide query --exclude "$(__zoxide_pwd)" -- "$@")" &&
             __zoxide_cd "${result}"
     fi
@@ -112,7 +114,7 @@ if [[ -o zle ]]; then
             _files -/
         elif [[ "${words[-1]}" == '' ]]; then
             \builtin local result
-            # shellcheck disable=SC2086
+            # shellcheck disable=SC2086,SC2312
             if result="$(\command zoxide query --exclude "$(__zoxide_pwd)" -i -- ${words[2,-1]})"; then
                 __zoxide_result="${result}"
             else


### PR DESCRIPTION
Just as mentioned in #341, use `\#` to indicate full path for zoxide to query.

In my tests it worked well.

resolved #341 