### PR TITLE
Add manual score adjustment

### DIFF
--- a/contrib/completions/_zoxide
+++ b/contrib/completions/_zoxide
@@ -30,6 +30,10 @@ _zoxide() {
         case $line[1] in
             (add)
 _arguments "${_arguments_options[@]}" \
+'(-d --decrement)-i+[Increment path(s) score by specified amount]:INCREMENT: ' \
+'(-d --decrement)--increment=[Increment path(s) score by specified amount]:INCREMENT: ' \
+'(-i --increment)-d+[Decrement path(s) score by specified amount. Score won'\''t go below 0]:DECREMENT: ' \
+'(-i --increment)--decrement=[Decrement path(s) score by specified amount. Score won'\''t go below 0]:DECREMENT: ' \
 '-h[Print help information]' \
 '--help[Print help information]' \
 '-V[Print version information]' \

--- a/contrib/completions/_zoxide.ps1
+++ b/contrib/completions/_zoxide.ps1
@@ -33,6 +33,10 @@ Register-ArgumentCompleter -Native -CommandName 'zoxide' -ScriptBlock {
             break
         }
         'zoxide;add' {
+            [CompletionResult]::new('-i', 'i', [CompletionResultType]::ParameterName, 'Increment path(s) score by specified amount')
+            [CompletionResult]::new('--increment', 'increment', [CompletionResultType]::ParameterName, 'Increment path(s) score by specified amount')
+            [CompletionResult]::new('-d', 'd', [CompletionResultType]::ParameterName, 'Decrement path(s) score by specified amount. Score won''t go below 0')
+            [CompletionResult]::new('--decrement', 'decrement', [CompletionResultType]::ParameterName, 'Decrement path(s) score by specified amount. Score won''t go below 0')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')

--- a/contrib/completions/zoxide.bash
+++ b/contrib/completions/zoxide.bash
@@ -48,12 +48,28 @@ _zoxide() {
             return 0
             ;;
         zoxide__add)
-            opts="-h -V --help --version <PATHS>..."
+            opts="-i -d -h -V --increment --decrement --help --version <PATHS>..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --increment)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --decrement)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -d)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;

--- a/contrib/completions/zoxide.elv
+++ b/contrib/completions/zoxide.elv
@@ -29,6 +29,10 @@ set edit:completion:arg-completer[zoxide] = {|@words|
             cand remove 'Remove a directory from the database'
         }
         &'zoxide;add'= {
+            cand -i 'Increment path(s) score by specified amount'
+            cand --increment 'Increment path(s) score by specified amount'
+            cand -d 'Decrement path(s) score by specified amount. Score won''t go below 0'
+            cand --decrement 'Decrement path(s) score by specified amount. Score won''t go below 0'
             cand -h 'Print help information'
             cand --help 'Print help information'
             cand -V 'Print version information'

--- a/contrib/completions/zoxide.fish
+++ b/contrib/completions/zoxide.fish
@@ -5,6 +5,8 @@ complete -c zoxide -n "__fish_use_subcommand" -f -a "import" -d 'Import entries 
 complete -c zoxide -n "__fish_use_subcommand" -f -a "init" -d 'Generate shell configuration'
 complete -c zoxide -n "__fish_use_subcommand" -f -a "query" -d 'Search for a directory in the database'
 complete -c zoxide -n "__fish_use_subcommand" -f -a "remove" -d 'Remove a directory from the database'
+complete -c zoxide -n "__fish_seen_subcommand_from add" -s i -l increment -d 'Increment path(s) score by specified amount' -r
+complete -c zoxide -n "__fish_seen_subcommand_from add" -s d -l decrement -d 'Decrement path(s) score by specified amount. Score won\'t go below 0' -r
 complete -c zoxide -n "__fish_seen_subcommand_from add" -s h -l help -d 'Print help information'
 complete -c zoxide -n "__fish_seen_subcommand_from add" -s V -l version -d 'Print version information'
 complete -c zoxide -n "__fish_seen_subcommand_from import" -l from -d 'Application to import from' -r -f -a "{autojump	,z	}"

--- a/contrib/completions/zoxide.ts
+++ b/contrib/completions/zoxide.ts
@@ -7,6 +7,30 @@ const completion: Fig.Spec = {
       description: "Add a new directory or increment its rank",
       options: [
         {
+          name: ["-i", "--increment"],
+          description: "Increment path(s) score by specified amount",
+          exclusiveOn: [
+            "-d",
+            "--decrement",
+          ],
+          args: {
+            name: "increment",
+            isOptional: true,
+          },
+        },
+        {
+          name: ["-d", "--decrement"],
+          description: "Decrement path(s) score by specified amount. Score won't go below 0",
+          exclusiveOn: [
+            "-i",
+            "--increment",
+          ],
+          args: {
+            name: "decrement",
+            isOptional: true,
+          },
+        },
+        {
           name: ["-h", "--help"],
           description: "Print help information",
         },

--- a/src/cmd/_cmd.rs
+++ b/src/cmd/_cmd.rs
@@ -33,6 +33,14 @@ pub enum Cmd {
 pub struct Add {
     #[clap(min_values = 1, required = true, value_hint = ValueHint::DirPath)]
     pub paths: Vec<PathBuf>,
+
+    /// Increment path(s) score by specified amount.
+    #[clap(long, short, conflicts_with = "decrement")]
+    pub increment: Option<u16>,
+
+    /// Decrement path(s) score by specified amount. Score won't go below 0.
+    #[clap(long, short, conflicts_with = "increment")]
+    pub decrement: Option<u16>,
 }
 
 /// Import entries from another application

--- a/src/cmd/add.rs
+++ b/src/cmd/add.rs
@@ -16,6 +16,13 @@ impl Run for Add {
         let exclude_dirs = config::exclude_dirs()?;
         let max_age = config::maxage()?;
         let now = util::current_time()?;
+        let increment = if let Some(num) = self.increment {
+            num as f64
+        } else if let Some(num) = self.decrement {
+            -(num as f64)
+        } else {
+            1.0
+        };
 
         let mut db = DatabaseFile::new(data_dir);
         let mut db = db.open()?;
@@ -31,7 +38,7 @@ impl Run for Add {
             if !Path::new(path).is_dir() {
                 bail!("not a directory: {}", path);
             }
-            db.add(path, now);
+            db.add(path, now, increment);
         }
 
         if db.modified {

--- a/src/db/dir.rs
+++ b/src/db/dir.rs
@@ -6,6 +6,10 @@ use anyhow::{bail, Context, Result};
 use bincode::Options as _;
 use serde::{Deserialize, Serialize};
 
+pub const HOUR: Epoch = 60 * 60;
+pub const DAY: Epoch = 24 * HOUR;
+pub const WEEK: Epoch = 7 * DAY;
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct DirList<'a>(#[serde(borrow)] pub Vec<Dir<'a>>);
 
@@ -89,10 +93,6 @@ pub struct Dir<'a> {
 
 impl Dir<'_> {
     pub fn score(&self, now: Epoch) -> Rank {
-        const HOUR: Epoch = 60 * 60;
-        const DAY: Epoch = 24 * HOUR;
-        const WEEK: Epoch = 7 * DAY;
-
         // The older the entry, the lesser its importance.
         let duration = now.saturating_sub(self.last_accessed);
         if duration < HOUR {


### PR DESCRIPTION
This commit adds '-i' and '-d' options to the 'zoxide add' command.
'-i' increments the base score by a specified amount.
'-d' decrements the base score by a specified amount.

Also added unit tests covering the new functionality combined with
recency scoring.

Fixes/Supports #392