### PR TITLE
Allow use of cd to positions in dirstack for zsh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fish: change fuzzy completion prefix to `z!`.
+- Zsh: allow `z` to navigate dirstack via `+n` and `-n`.
 
 ## [0.8.2] - 2022-06-26
 

--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -67,7 +67,7 @@ function __zoxide_z() {
             \builtin printf 'zoxide: $OLDPWD is not set'
             return 1
         fi
-    elif [[ "$#" -eq 1 ]] && [[ -d "$1" ]]; then
+    elif [[ "$#" -eq 1 ]] && [[ -d "$1" ]] || [[ "$1" =~ ^[-+][1-9]$ ]]; then
         __zoxide_cd "$1"
     elif [[ "$@[-1]" == "${__zoxide_z_prefix}"* ]]; then
         # shellcheck disable=SC2124

--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -19,7 +19,7 @@ function __zoxide_pwd() {
 # cd + custom logic based on the value of _ZO_ECHO.
 function __zoxide_cd() {
     # shellcheck disable=SC2164
-    \builtin cd -- "$@" {%- if echo %} && __zoxide_pwd {%- endif %}
+    \builtin cd -- "$@" >/dev/null {%- if echo %} && __zoxide_pwd {%- endif %}
 }
 
 {{ section }}
@@ -59,15 +59,7 @@ function __zoxide_z() {
     # shellcheck disable=SC2199
     if [[ "$#" -eq 0 ]]; then
         __zoxide_cd ~
-    elif [[ "$#" -eq 1 ]] && [[ "$1" = '-' ]]; then
-        if [[ -n "${OLDPWD}" ]]; then
-            __zoxide_cd "${OLDPWD}"
-        else
-            # shellcheck disable=SC2016
-            \builtin printf 'zoxide: $OLDPWD is not set'
-            return 1
-        fi
-    elif [[ "$#" -eq 1 ]] && [[ -d "$1" ]] || [[ "$1" =~ ^[-+][1-9]$ ]]; then
+    elif [[ "$#" -eq 1 ]] && { [[ -d "$1" ]] || [[ "$1" = '-' ]] || [[ "$1" =~ ^[-+][0-9]$ ]]; }; then
         __zoxide_cd "$1"
     elif [[ "$@[-1]" == "${__zoxide_z_prefix}"* ]]; then
         # shellcheck disable=SC2124


### PR DESCRIPTION
man zshbuiltins excerpt:

> The  third  form  of  cd extracts an entry from the directory stack, and
> changes to that directory.  An argument of the form  '+n'  identifies  a
> stack entry by counting from the left of the list shown by the dirs com‐
> mand, starting with zero.  An argument of the form '-n' counts from  the
> right.  If the PUSHD_MINUS option is set, the meanings of '+' and '-' in
> this context are swapped.  If the POSIX_CD option is set, this  form  of
> cd is not recognised and will be interpreted as the first form.