### PR TITLE
remove quotes for COMPREPLY in bash.txt

### DIFF
--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -82,7 +82,7 @@ function __zoxide_z() {
     else
         \builtin local result
         # shellcheck disable=SC2312
-        result=$(\command zoxide query --exclude "$(__zoxide_pwd)" -- "$@") &&
+        result="$(\command zoxide query --exclude "$(__zoxide_pwd)" -- "$@")" &&
             __zoxide_cd "${result}"
     fi
 }
@@ -90,7 +90,7 @@ function __zoxide_z() {
 # Jump to a directory using interactive search.
 function __zoxide_zi() {
     \builtin local result
-    result=$(\command zoxide query -i -- "$@") && __zoxide_cd "${result}"
+    result="$(\command zoxide query -i -- "$@")" && __zoxide_cd "${result}"
 }
 
 {{ section }}
@@ -133,7 +133,7 @@ if [[ ${BASH_VERSINFO[0]:-0} -eq 4 && ${BASH_VERSINFO[1]:-0} -ge 4 || ${BASH_VER
         elif [[ -z ${COMP_WORDS[-1]} ]]; then
             \builtin local result
             # shellcheck disable=SC2312
-            result=$(\command zoxide query --exclude "$(__zoxide_pwd)" -i -- "{{ "${COMP_WORDS[@]:1:${#COMP_WORDS[@]}-2}" }}") &&
+            result="$(\command zoxide query --exclude "$(__zoxide_pwd)" -i -- "{{ "${COMP_WORDS[@]:1:${#COMP_WORDS[@]}-2}" }}")" &&
                 COMPREPLY=${__zoxide_z_prefix}${result}/
             \builtin printf '\e[5n'
         fi

--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -82,7 +82,7 @@ function __zoxide_z() {
     else
         \builtin local result
         # shellcheck disable=SC2312
-        result="$(\command zoxide query --exclude "$(__zoxide_pwd)" -- "$@")" &&
+        result=$(\command zoxide query --exclude "$(__zoxide_pwd)" -- "$@") &&
             __zoxide_cd "${result}"
     fi
 }
@@ -90,7 +90,7 @@ function __zoxide_z() {
 # Jump to a directory using interactive search.
 function __zoxide_zi() {
     \builtin local result
-    result="$(\command zoxide query -i -- "$@")" && __zoxide_cd "${result}"
+    result=$(\command zoxide query -i -- "$@") && __zoxide_cd "${result}"
 }
 
 {{ section }}
@@ -133,8 +133,8 @@ if [[ ${BASH_VERSINFO[0]:-0} -eq 4 && ${BASH_VERSINFO[1]:-0} -ge 4 || ${BASH_VER
         elif [[ -z ${COMP_WORDS[-1]} ]]; then
             \builtin local result
             # shellcheck disable=SC2312
-            result="$(\command zoxide query --exclude "$(__zoxide_pwd)" -i -- "{{ "${COMP_WORDS[@]:1:${#COMP_WORDS[@]}-2}" }}")" &&
-                COMPREPLY=("${__zoxide_z_prefix}${result}/")
+            result=$(\command zoxide query --exclude "$(__zoxide_pwd)" -i -- "{{ "${COMP_WORDS[@]:1:${#COMP_WORDS[@]}-2}" }}") &&
+                COMPREPLY=${__zoxide_z_prefix}${result}/
             \builtin printf '\e[5n'
         fi
     }


### PR DESCRIPTION
This fixes my z command not working in bash. The zoxide command works fine. Not sure if I'm missing something or some bash setting but the quotes seem extraneous per this [link](https://linuxhint.com/bash_command_output_variable/).