### PR TITLE
Fix interactive completion with zsh-autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- zsh: completions clashing with `zsh-autocomplete`.
+
 ## [0.8.3] - 2022-09-02
 
 ### Added

--- a/templates/elvish.txt
+++ b/templates/elvish.txt
@@ -87,8 +87,10 @@ edit:add-var {{cmd}}~ $__zoxide_z~
 edit:add-var {{cmd}}i~ $__zoxide_zi~
 
 # Load completions.
-{# zoxide-based completions are currently not possible, because Elvish only
- # prints a completion if the current token is a prefix of it. -#}
+{#-
+  zoxide-based completions are currently not possible, because Elvish only prints
+  a completion if the current token is a prefix of it.
+#}
 fn __zoxide_z_complete {|@rest|
     if (!= (builtin:count $rest) 2) {
         builtin:return

--- a/templates/powershell.txt
+++ b/templates/powershell.txt
@@ -38,8 +38,10 @@ function __zoxide_hook {
 }
 
 # Initialize hook.
-{# Initialize $__zoxide_hooked if it does not exist. Removing this will cause
- # an unset variable error in StrictMode. #}
+{#-
+  Initialize $__zoxide_hooked if it does not exist. Removing this will cause an
+  unset variable error in StrictMode.
+#}
 $__zoxide_hooked = (Get-Variable __zoxide_hooked -ValueOnly -ErrorAction SilentlyContinue)
 if ($__zoxide_hooked -ne 1) {
     $__zoxide_hooked = 1

--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -112,6 +112,10 @@ if [[ -o zle ]]; then
             else
                 __zoxide_result=''
             fi
+            if [[ -v functions[.autocomplete._complete] ]]; then
+                # zsh-autocomplete needs a match or it will run __zoxide_z_complete multiple times
+                compadd ""
+            fi
             \builtin printf '\e[5n'
         fi
     }

--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -108,12 +108,14 @@ if [[ -o zle ]]; then
             \builtin local result
             # shellcheck disable=SC2086,SC2312
             if result="$(\command zoxide query --exclude "$(__zoxide_pwd)" -i -- ${words[2,-1]})"; then
-                __zoxide_result="${result}"
+                result="${__zoxide_z_prefix}${result}"
+                # shellcheck disable=SC2296
+                compadd -Q "${(q-)result}"
             else
-                __zoxide_result=''
-            fi
-            if [[ -v functions[.autocomplete._complete] ]]; then
-                # zsh-autocomplete needs a match or it will run __zoxide_z_complete multiple times
+{#-
+  zsh-autocomplete calls the completion function multiple times if no match is
+  returned.
+#}
                 compadd ""
             fi
             \builtin printf '\e[5n'
@@ -121,9 +123,6 @@ if [[ -o zle ]]; then
     }
 
     function __zoxide_z_complete_helper() {
-        \builtin local result="${__zoxide_z_prefix}${__zoxide_result}"
-        # shellcheck disable=SC2296
-        [[ -n "${__zoxide_result}" ]] && LBUFFER="${LBUFFER}${(q-)result}"
         \builtin zle reset-prompt
     }
 

--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -122,12 +122,7 @@ if [[ -o zle ]]; then
         fi
     }
 
-    function __zoxide_z_complete_helper() {
-        \builtin zle reset-prompt
-    }
-
-    \builtin zle -N __zoxide_z_complete_helper
-    \builtin bindkey "\e[0n" __zoxide_z_complete_helper
+    \builtin bindkey "\e[0n" 'reset-prompt'
     if [[ "${+functions[compdef]}" -ne 0 ]]; then
         \compdef -d {{cmd}}
         \compdef -d {{cmd}}i


### PR DESCRIPTION
## Problem
With [zsh-autocomplete](https://github.com/marlonrichert/zsh-autocomplete) and fzf installed, `z foo<SPACE><TAB>` opens the fzf picker as expected, but upon pressing `<ENTER>`, the prompt disappears and the fzf picker goes blank, with the text `0n` entered (screenshot below).

<img width="331" alt="Last login Sat Sep 3 003804 on ttys008" src="https://user-images.githubusercontent.com/7785912/188256126-45d0da8b-8350-4863-a466-c1549110ce39.png">

Pressing escape three times returns me to the prompt, with no completion entered.

Pressing enter causes the error `zoxide: no match found` to be printed and fzf to reopen, again with the text `0n`.

## Cause
This is because zsh-autocomplete patches the `_complete` function (and others) to return an error if no new matches are found:
```zsh
% which _complete
_complete () {
	local -i nmatches=$compstate[nmatches]
	.autocomplete._complete "$@" || _autocomplete.ancestor_dirs "$@" || _autocomplete.recent_paths "$@"
	(( compstate[nmatches] > nmatches ))
}
```
and `__zoxide_z_complete` can be called by different completion functions after each one returns an error. Each time, this launches a new fzf picker before `\e[0n` can be input to the shell, so fzf catches it instead.

## Solution
If `__zoxide_z_complete` sees that zsh-autocomplete is present (e.g. by seeing that the patched function `.autocomplete._complete` is present), it should add an empty completion match. 

zsh-autocomplete will use the empty match and not run `__zoxide_z_complete` a second time, so `__zoxide_z_complete_helper` will work as expected.

## Alternative
[aaronkollasch:zsh-autocomplete-compat-2](https://github.com/aaronkollasch/zoxide/tree/zsh-autocomplete-compat-2)

Instead of checking for zsh-autocomplete and creating an empty completion, a more general solution is to send the zoxide result through zsh's completion system, like so:
```zsh
\builtin local result="${__zoxide_z_prefix}${__zoxide_result}"
compadd -Q "${(q-)result}"
```
Then, `__zoxide_z_complete_helper` only needs to reset the prompt.
I've tested this and it seems to work, both with zsh-autocomplete and using compinit with its default settings.

---

Fixes https://github.com/ajeetdsouza/zoxide/issues/338.