### PR TITLE
Fix typo in README.md about nushell version compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ source ~/.zoxide.nu
 ```
 
 > **Note**
-> zoxide only supports Nushell v0.73.0 and above.
+> zoxide only supports Nushell v0.63.0 and above.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ source ~/.zoxide.nu
 ```
 
 > **Note**
-> zoxide only supports Nushell v0.63.0 and above.
+> zoxide only supports Nushell v0.63.0 and above, and `-f` is needed and supported only in Nushell v0.73 and above.
 
 </details>
 


### PR DESCRIPTION
Fixed on basis of comment in `zoxide init nushell` output.