### PR TITLE
Support nushell breaking change

### DIFF
--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -18,7 +18,7 @@ if (not ($env | default false __zoxide_hooked | get __zoxide_hooked)) {
   let-env config = ($env | default {} config).config
   let-env config = ($env.config | default {} hooks)
   let-env config = ($env.config | update hooks ($env.config.hooks | default [] pre_prompt))
-  let-env config = ($env.config | update hooks.pre_prompt ($env.config.hooks.pre_prompt | append {
+  let-env config = ($env.config | update hooks.pre_prompt ($env.config.hooks.pre_prompt | append { ||
     zoxide add -- $env.PWD
   }))
 {%- else if hook == InitHook::Pwd %}


### PR DESCRIPTION
Nushell had a breaking change in 0.78.0, requiring closures to now have argument lists in pipe characters. Since the closure changed here takes no arguments, this just looks like `||`. I have run `cargo run -- init --hook prompt > init.nu; source init.nu` to verify that it is working now. Closes #551.