### PR TITLE
allow user specification of bin_dir, bin_name, and man_dir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,9 +48,10 @@ main() {
 
     # Install binary.
     local _bin_dir="${BINDIR:-${HOME}/.local/bin}"
-    local _bin_name="${BINNAME:-zoxide}"
+    local _bin_name
     case "${_arch}" in
     *windows*) _bin_name="$_bin_name.exe" ;;
+    *) _bin_name="zoxide" ;;
     esac
     ensure mkdir -p "${_bin_dir}"
     ensure cp "${_bin_name}" "${_bin_dir}"

--- a/install.sh
+++ b/install.sh
@@ -47,11 +47,10 @@ main() {
     esac
 
     # Install binary.
-    local _bin_dir="${HOME}/.local/bin"
-    local _bin_name
+    local _bin_dir="${BINDIR:-${HOME}/.local/bin}"
+    local _bin_name="${BINNAME:-zoxide}"
     case "${_arch}" in
-    *windows*) _bin_name="zoxide.exe" ;;
-    *) _bin_name="zoxide" ;;
+    *windows*) _bin_name="$_bin_name.exe" ;;
     esac
     ensure mkdir -p "${_bin_dir}"
     ensure cp "${_bin_name}" "${_bin_dir}"
@@ -59,7 +58,7 @@ main() {
     echo "Installed zoxide to ${_bin_dir}"
 
     # Install manpages.
-    local _man_dir="${HOME}/.local/share/man"
+    local _man_dir="${MANDIR:-${HOME}/.local/share/man}"
     ensure mkdir -p "${_man_dir}/man1"
     ensure cp "man/man1/"* "${_man_dir}/man1/"
     echo "Installed manpages to ${_man_dir}"

--- a/install.sh
+++ b/install.sh
@@ -50,7 +50,7 @@ main() {
     local _bin_dir="${BINDIR:-${HOME}/.local/bin}"
     local _bin_name
     case "${_arch}" in
-    *windows*) _bin_name="$_bin_name.exe" ;;
+    *windows*) _bin_name="zoxide.exe" ;;
     *) _bin_name="zoxide" ;;
     esac
     ensure mkdir -p "${_bin_dir}"


### PR DESCRIPTION
This allows the user to choose the installation directory, the name of the executable, and the `man` directory using the environment variables `BINDIR`, `BINNAME`, and `MANDIR`, respectively.
