### PR TITLE
add self-import to merge multiple zoxide databases

### DIFF
--- a/contrib/completions/_zoxide
+++ b/contrib/completions/_zoxide
@@ -94,7 +94,7 @@ esac
 ;;
 (import)
 _arguments "${_arguments_options[@]}" \
-'--from=[Application to import from]:FROM:(autojump z)' \
+'--from=[Application to import from]:FROM:(autojump z zoxide)' \
 '--merge[Merge into existing database]' \
 '-h[Print help]' \
 '--help[Print help]' \

--- a/contrib/completions/zoxide.bash
+++ b/contrib/completions/zoxide.bash
@@ -154,7 +154,7 @@ _zoxide() {
             fi
             case "${prev}" in
                 --from)
-                    COMPREPLY=($(compgen -W "autojump z" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "autojump z zoxide" -- "${cur}"))
                     return 0
                     ;;
                 *)

--- a/contrib/completions/zoxide.fish
+++ b/contrib/completions/zoxide.fish
@@ -22,7 +22,7 @@ complete -c zoxide -n "__fish_seen_subcommand_from edit; and __fish_seen_subcomm
 complete -c zoxide -n "__fish_seen_subcommand_from edit; and __fish_seen_subcommand_from increment" -s V -l version -d 'Print version'
 complete -c zoxide -n "__fish_seen_subcommand_from edit; and __fish_seen_subcommand_from reload" -s h -l help -d 'Print help'
 complete -c zoxide -n "__fish_seen_subcommand_from edit; and __fish_seen_subcommand_from reload" -s V -l version -d 'Print version'
-complete -c zoxide -n "__fish_seen_subcommand_from import" -l from -d 'Application to import from' -r -f -a "{autojump	,z	}"
+complete -c zoxide -n "__fish_seen_subcommand_from import" -l from -d 'Application to import from' -r -f -a "{autojump	,z	,zoxide	}"
 complete -c zoxide -n "__fish_seen_subcommand_from import" -l merge -d 'Merge into existing database'
 complete -c zoxide -n "__fish_seen_subcommand_from import" -s h -l help -d 'Print help'
 complete -c zoxide -n "__fish_seen_subcommand_from import" -s V -l version -d 'Print version'

--- a/contrib/completions/zoxide.ts
+++ b/contrib/completions/zoxide.ts
@@ -115,6 +115,7 @@ const completion: Fig.Spec = {
             suggestions: [
               "autojump",
               "z",
+              "zoxide",
             ],
           },
         },

--- a/src/cmd/cmd.rs
+++ b/src/cmd/cmd.rs
@@ -97,6 +97,7 @@ pub enum ImportFrom {
     Autojump,
     #[clap(alias = "fasd")]
     Z,
+    Zoxide,
 }
 
 /// Generate shell configuration

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -206,7 +206,7 @@ impl Database {
         .context("could not serialize database")
     }
 
-    fn deserialize(bytes: &[u8]) -> Result<Vec<Dir>> {
+    pub(crate) fn deserialize(bytes: &[u8]) -> Result<Vec<Dir>> {
         // Assume a maximum size for the database. This prevents bincode from throwing
         // strange errors when it encounters invalid data.
         const MAX_SIZE: u64 = 32 << 20; // 32 MiB


### PR DESCRIPTION
Roughly a year ago I needed a feature in zoxide, and added in my local checkout to test-drive it. 

I just realized that I totally forgot to create the PR :) 

I'm using symlinks / dropbox to sync many things across my machines, and sometimes there are conflicts and then dropbox will duplicate the files. 

With the help of a script and this new option, I can merge these together to have a consistent directory list & history / ranking across machines. 

