### PR TITLE
clarify "unsupported [database] version" error message

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -226,7 +226,10 @@ impl Database {
                 deserializer.deserialize(bytes_dirs).context("could not deserialize database")?
             }
             version => {
-                bail!("unsupported version (got {version}, supports {})", Self::VERSION)
+                bail!(
+                    "unsupported database version (got {version}, supports {}), re-create the database",
+                    Self::VERSION
+                )
             }
         };
 


### PR DESCRIPTION
When using an incompatible database version (e.g. from an old install of zoxide) this message is displayed frequently. The message should provide helpful information about the underlying problem and possible solution(s).

If it's not possible to migrate from one db version to another, maybe we should just delete the old db.zo instead of failing?