### PR TITLE
Update Nushell env update syntax

### DIFF
--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -13,20 +13,20 @@
 {%- else -%}
 # Initialize hook to add new entries to the database.
 if (not ($env | default false __zoxide_hooked | get __zoxide_hooked)) {
-  let-env __zoxide_hooked = true
+  $env.__zoxide_hooked = true
 {%- if hook == InitHook::Prompt %}
-  let-env config = ($env | default {} config).config
-  let-env config = ($env.config | default {} hooks)
-  let-env config = ($env.config | update hooks ($env.config.hooks | default [] pre_prompt))
-  let-env config = ($env.config | update hooks.pre_prompt ($env.config.hooks.pre_prompt | append { ||
+  $env.config = ($env | default {} config).config
+  $env.config = ($env.config | default {} hooks)
+  $env.config = ($env.config | update hooks ($env.config.hooks | default [] pre_prompt))
+  $env.config = ($env.config | update hooks.pre_prompt ($env.config.hooks.pre_prompt | append { ||
     zoxide add -- $env.PWD
   }))
 {%- else if hook == InitHook::Pwd %}
-  let-env config = ($env | default {} config).config
-  let-env config = ($env.config | default {} hooks)
-  let-env config = ($env.config | update hooks ($env.config.hooks | default {} env_change))
-  let-env config = ($env.config | update hooks.env_change ($env.config.hooks.env_change | default [] PWD))
-  let-env config = ($env.config | update hooks.env_change.PWD ($env.config.hooks.env_change.PWD | append {|_, dir|
+  $env.config = ($env | default {} config).config
+  $env.config = ($env.config | default {} hooks)
+  $env.config = ($env.config | update hooks ($env.config.hooks | default {} env_change))
+  $env.config = ($env.config | update hooks.env_change ($env.config.hooks.env_change | default [] PWD))
+  $env.config = ($env.config | update hooks.env_change.PWD ($env.config.hooks.env_change.PWD | append {|_, dir|
     zoxide add -- $dir
   }))
 {%- endif %}


### PR DESCRIPTION
Greetings!

The Nushell team is planning to move away from `let-env FOO = ...` to the more straightforward (and more honest) `$env.FOO = ...`.

This PR should update zoxide to use the supported environment update syntax.