### PR TITLE
fix: use `str length` for str instead of `length`

### DIFF
--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -41,7 +41,7 @@ if (not ($env | default false __zoxide_hooked | get __zoxide_hooked)) {
 # Jump to a directory using only keywords.
 def-env __zoxide_z [...rest:string] {
   let arg0 = ($rest | append '~').0
-  let path = if (($rest | length) <= 1) and ($arg0 == '-' or ($arg0 | path expand | path type) == dir) {
+  let path = if (($rest | str length) <= 1) and ($arg0 == '-' or ($arg0 | path expand | path type) == dir) {
     $arg0
   } else {
     (zoxide query --exclude $env.PWD -- $rest | str trim -r -c "\n")

--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -39,9 +39,10 @@ if (not ($env | default false __zoxide_hooked | get __zoxide_hooked)) {
 #
 
 # Jump to a directory using only keywords.
-def-env __zoxide_z [...rest:string] {
+# def-env __zoxide_z [...rest:string] {
+def-env __zoxide_z [...rest] {
   let arg0 = ($rest | append '~').0
-  let path = if (($rest | str length) <= 1) and ($arg0 == '-' or ($arg0 | path expand | path type) == dir) {
+  let path = if (($rest | length) <= 1) and ($arg0 == '-' or ($arg0 | path expand | path type) == dir) {
     $arg0
   } else {
     (zoxide query --exclude $env.PWD -- $rest | str trim -r -c "\n")
@@ -53,7 +54,8 @@ def-env __zoxide_z [...rest:string] {
 }
 
 # Jump to a directory using interactive search.
-def-env __zoxide_zi  [...rest:string] {
+# def-env __zoxide_zi  [...rest:string] {
+def-env __zoxide_zi  [...rest] {
   cd $'(zoxide query --interactive -- $rest | str trim -r -c "\n")'
 {%- if echo %}
   echo $env.PWD


### PR DESCRIPTION
nushell won't start as long as you use `length`.

```
[1 2 3 4] | length
```
works.

```
"hello world" | str length
```
works.

Different permutations don't.