### PR TITLE
Remove unexpected token

### DIFF
--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -126,7 +126,7 @@ if [[ ${BASH_VERSINFO[0]:-0} -eq 4 && ${BASH_VERSINFO[1]:-0} -ge 4 || ${BASH_VER
 
         # If there is only one argument, use `cd` completions.
         if [[ {{ "${#COMP_WORDS[@]}" }} -eq 2 ]]; then
-            \builtin mapfile -t COMPREPLY < <(
+            \builtin mapfile -t COMPREPLY < (
                 \builtin compgen -A directory -- "${COMP_WORDS[-1]}" || \builtin true
             )
         # If there is a space after the last word, use interactive selection.


### PR DESCRIPTION
This tries to fix the following issue:
```bash
/root/.bashrc: eval: line 308: syntax error near unexpected token `<'                        
/root/.bashrc: eval: line 308: `            \builtin mapfile -t COMPREPLY < <('
```