### PR TITLE
Fix handling of directories that look like flags in fish

### DIFF
--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -76,7 +76,7 @@ function __zoxide_z
         __zoxide_cd -
     else if test $argc -eq 1 -a -d $argv[1]
         __zoxide_cd $argv[1]
-    else if set -l result (string replace --regex $__zoxide_z_prefix_regex '' $argv[-1]); and test -n $result
+    else if set -l result (string replace --regex -- $__zoxide_z_prefix_regex '' $argv[-1]); and test -n $result
         __zoxide_cd $result
     else
         set -l result (command zoxide query --exclude (__zoxide_pwd) -- $argv)


### PR DESCRIPTION
When installed in Fish, `z -C` or `z -s` or similar flags unrecognized by Fish’s `string replace` error out with:

```
string replace: -s: unknown option

- (line 1): 
in command substitution
	called on line 56 of file -
in function '__zoxide_z' with arguments '-s'
	called on line 1 of file -
in function 'z' with arguments '-s'

(Type 'help string' for related documentation)
```

This addresses that by adding a `--` separator in the `string replace` call, which suppresses interpretation of flags.
