### PR TITLE
Normalize drive letters when resolving paths on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - zsh: better cd completions.
 - elvish: `z -` now work as expected.
 - Lazily delete excluded directories from the database.
+- Normalize drive letters when resolving paths on Windows.
 
 ## [0.9.4] - 2024-02-21
 

--- a/src/cmd/add.rs
+++ b/src/cmd/add.rs
@@ -19,10 +19,11 @@ impl Run for Add {
         let mut db = Database::open()?;
 
         for path in &self.paths {
-            let path =
-                if config::resolve_symlinks() { util::canonicalize } else { util::resolve_path }(
-                    path,
-                )?;
+            let path = util::patch_path(if config::resolve_symlinks() {
+                util::canonicalize
+            } else {
+                util::resolve_path
+            }(path)?);
             let path = util::path_to_str(&path)?;
 
             // Ignore path if it contains unsupported characters, or if it's in the exclude


### PR DESCRIPTION
When it comes to resolving paths on Windows, even though the underlying API expects drive letter prefixes to be uppercase, some sources (e.g. environment variables like `=C:`) won't normalize components, instead returning the value as-is. While this wouldn't be a problem normally as NTFS is case-insensitive on Windows, this introduces duplicates in the database when adding new entries via `zoxide add`:

```batchfile prompt
> zoxide query --list
D:\
d:\
D:\coding
d:\coding
D:\coding\.cloned
d:\coding\.cloned
```

This is a cherry-pick from #567; see also rust-lang/rust-analyzer#14683.