### PR TITLE
Specify exact winget id

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ zoxide can be installed in 4 easy steps:
    > The recommended way to install zoxide is via `winget`:
    >
    > ```sh
-   > winget install zoxide
+   > winget install ajeetdsouza.zoxide
    > ```
    >
    > Or, you can use an alternative package manager:


### PR DESCRIPTION
Specifies exact winget identifier

---

Reasoning: I have a wrapper `winget-install` script that enforces a consistent location. It also uses `-e` to only install exact matches. So, I figured this README should show the exact ID.

Feel free to reject/close if you prefer just `zoxide`.