### PR TITLE
Remove creation of file z! on init in fish

### DIFF
--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -65,7 +65,7 @@ end
 if test -z $__zoxide_z_prefix
     set __zoxide_z_prefix 'z!'
 end
-set __zoxide_z_prefix_regex ^(string escape --style=regex $__zoxide_z_prefix)
+set __zoxide_z_prefix_regex (string escape --style=regex $__zoxide_z_prefix)
 
 # Jump to a directory using only keywords.
 function __zoxide_z


### PR DESCRIPTION
In fish 3.1 executing `zoxide init fish | source` creates file `z!` in working directory. Some experimentation showed, that such commands: `echo ^(echo 'z!')` have similar effect.
Caret removal fixes issue with creating files and does not affect init behaivour:
```
$ cat ~/.config/fish/zoxide_init | source
$ echo $__zoxide_z_prefix_regex
z!
```
(zoxide_init is changed init script)