### PR TITLE
Update nushell.txt to fit nushell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Nushell: add support for v0.86.0.
+
 ## [0.9.2] - 2023-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ zoxide can be installed in 4 easy steps:
    > ```
    >
    > **Note**
-   > zoxide only supports Nushell v0.73.0 and above.
+   > zoxide only supports Nushell v0.86.0+.
 
    </details>
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <div>
     <img src="contrib/warp.png" width="230" alt="Warp" />
   </div>
-  <b>Warp is a modern, Rust-based terminal with AI built in so you 
+  <b>Warp is a modern, Rust-based terminal with AI built in so you
     and your team can build great software, faster.</b>
   <div>
     <sup>Visit <u>warp.dev</u> to learn more.</sup>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
   <div>
     <img src="contrib/warp.png" width="230" alt="Warp" />
   </div>
-  <b>Warp is a modern, Rust-based terminal with AI built in so you and your team can build great software, faster.</b>
+  <b>Warp is a modern, Rust-based terminal with AI built in so you 
+    and your team can build great software, faster.</b>
   <div>
     <sup>Visit <u>warp.dev</u> to learn more.</sup>
   </div>

--- a/man/man1/zoxide-init.1
+++ b/man/man1/zoxide-init.1
@@ -45,7 +45,7 @@ Now, add this to the \fBend\fR of your config file (find it by running
     \fBsource ~/.zoxide.nu\fR
 .fi
 .sp
-Note: zoxide only supports Nushell v0.73.0 and above.
+Note: zoxide only supports Nushell v0.86.0+.
 .TP
 .B powershell
 Add this to the \fBend\fR of your config file (find it by running \fBecho

--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -39,7 +39,7 @@ if (not ($env | default false __zoxide_hooked | get __zoxide_hooked)) {
 #
 
 # Jump to a directory using only keywords.
-def-env __zoxide_z [...rest:string] {
+def --env __zoxide_z [...rest:string] {
   let arg0 = ($rest | append '~').0
   let path = if (($rest | length) <= 1) and ($arg0 == '-' or ($arg0 | path expand | path type) == dir) {
     $arg0
@@ -53,7 +53,7 @@ def-env __zoxide_z [...rest:string] {
 }
 
 # Jump to a directory using interactive search.
-def-env __zoxide_zi  [...rest:string] {
+def --env __zoxide_zi  [...rest:string] {
   cd $'(zoxide query --interactive -- $rest | str trim -r -c "\n")'
 {%- if echo %}
   echo $env.PWD

--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -86,4 +86,4 @@ alias {{cmd}}i = __zoxide_zi
 #
 #   source ~/.zoxide.nu
 #
-# Note: zoxide only supports Nushell v0.73.0 and above.
+# Note: zoxide only supports Nushell v0.86.0+.


### PR DESCRIPTION
Change the `def-env` to `def --env` to fit the nushell v8.8, because the `def-env` is deprecated and be removed in v8.8

Fixes https://github.com/ajeetdsouza/zoxide/issues/630