### PR TITLE
Make zoxide compitable with upcoming nushell release

### DIFF
--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -39,7 +39,7 @@ if (not ($env | default false __zoxide_hooked | get __zoxide_hooked)) {
 #
 
 # Jump to a directory using only keywords.
-def-env __zoxide_z [...rest:string] {
+def --env __zoxide_z [...rest:string] {
   let arg0 = ($rest | append '~').0
   let path = if (($rest | length) <= 1) and ($arg0 == '-' or ($arg0 | path expand | path type) == dir) {
     $arg0
@@ -53,7 +53,7 @@ def-env __zoxide_z [...rest:string] {
 }
 
 # Jump to a directory using interactive search.
-def-env __zoxide_zi  [...rest:string] {
+def --env __zoxide_zi  [...rest:string] {
   cd $'(zoxide query --interactive -- $rest | str trim -r -c "\n")'
 {%- if echo %}
   echo $env.PWD


### PR DESCRIPTION
nushell will deprecate `def-env` and use `def --env` in the next release(0.87)

Currently `def --env` is already available in latest version (0.86)

Relative: #630