### PR TITLE
Add limit option for zoxide query

### DIFF
--- a/contrib/completions/_zoxide
+++ b/contrib/completions/_zoxide
@@ -117,6 +117,8 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (query)
 _arguments "${_arguments_options[@]}" \
+'-n+[Limit number of results in List mode]:LIMIT: ' \
+'--limit=[Limit number of results in List mode]:LIMIT: ' \
 '--exclude=[Exclude the current directory]:path:_files -/' \
 '-a[Show unavailable directories]' \
 '--all[Show unavailable directories]' \

--- a/contrib/completions/_zoxide.ps1
+++ b/contrib/completions/_zoxide.ps1
@@ -99,6 +99,8 @@ Register-ArgumentCompleter -Native -CommandName 'zoxide' -ScriptBlock {
             break
         }
         'zoxide;query' {
+            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'Limit number of results in List mode')
+            [CompletionResult]::new('--limit', 'limit', [CompletionResultType]::ParameterName, 'Limit number of results in List mode')
             [CompletionResult]::new('--exclude', 'exclude', [CompletionResultType]::ParameterName, 'Exclude the current directory')
             [CompletionResult]::new('-a', 'a', [CompletionResultType]::ParameterName, 'Show unavailable directories')
             [CompletionResult]::new('--all', 'all', [CompletionResultType]::ParameterName, 'Show unavailable directories')

--- a/contrib/completions/zoxide.bash
+++ b/contrib/completions/zoxide.bash
@@ -187,12 +187,20 @@ _zoxide() {
             return 0
             ;;
         zoxide__query)
-            opts="-a -i -l -s -h -V --all --interactive --list --score --exclude --help --version [KEYWORDS]..."
+            opts="-a -i -l -n -s -h -V --all --interactive --list --limit --score --exclude --help --version [KEYWORDS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --limit)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -n)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --exclude)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0

--- a/contrib/completions/zoxide.elv
+++ b/contrib/completions/zoxide.elv
@@ -87,6 +87,8 @@ set edit:completion:arg-completer[zoxide] = {|@words|
             cand --version 'Print version'
         }
         &'zoxide;query'= {
+            cand -n 'Limit number of results in List mode'
+            cand --limit 'Limit number of results in List mode'
             cand --exclude 'Exclude the current directory'
             cand -a 'Show unavailable directories'
             cand --all 'Show unavailable directories'

--- a/contrib/completions/zoxide.fish
+++ b/contrib/completions/zoxide.fish
@@ -31,6 +31,7 @@ complete -c zoxide -n "__fish_seen_subcommand_from init" -l hook -d 'Changes how
 complete -c zoxide -n "__fish_seen_subcommand_from init" -l no-cmd -d 'Prevents zoxide from defining the `z` and `zi` commands'
 complete -c zoxide -n "__fish_seen_subcommand_from init" -s h -l help -d 'Print help'
 complete -c zoxide -n "__fish_seen_subcommand_from init" -s V -l version -d 'Print version'
+complete -c zoxide -n "__fish_seen_subcommand_from query" -s n -l limit -d 'Limit number of results in List mode' -r
 complete -c zoxide -n "__fish_seen_subcommand_from query" -l exclude -d 'Exclude the current directory' -r -f -a "(__fish_complete_directories)"
 complete -c zoxide -n "__fish_seen_subcommand_from query" -s a -l all -d 'Show unavailable directories'
 complete -c zoxide -n "__fish_seen_subcommand_from query" -s i -l interactive -d 'Use interactive selection'

--- a/contrib/completions/zoxide.ts
+++ b/contrib/completions/zoxide.ts
@@ -195,6 +195,15 @@ const completion: Fig.Spec = {
       description: "Search for a directory in the database",
       options: [
         {
+          name: ["-n", "--limit"],
+          description: "Limit number of results in List mode",
+          isRepeatable: true,
+          args: {
+            name: "limit",
+            isOptional: true,
+          },
+        },
+        {
           name: "--exclude",
           description: "Exclude the current directory",
           isRepeatable: true,

--- a/src/cmd/cmd.rs
+++ b/src/cmd/cmd.rs
@@ -165,6 +165,10 @@ pub struct Query {
     #[clap(long, short, conflicts_with = "interactive")]
     pub list: bool,
 
+    /// Limit number of results in List mode
+    #[clap(long, short('n'))]
+    pub limit: Option<usize>,
+
     /// Print score with results
     #[clap(long, short)]
     pub score: bool,

--- a/src/cmd/query.rs
+++ b/src/cmd/query.rs
@@ -41,9 +41,14 @@ impl Query {
             }
         } else if self.list {
             let handle = &mut io::stdout().lock();
+            let mut limit = self.limit.unwrap_or(usize::MAX);
             while let Some(dir) = stream.next() {
+                if limit == 0 {
+                    break;
+                }
                 let dir = if self.score { dir.display().with_score(now) } else { dir.display() };
                 writeln!(handle, "{dir}").pipe_exit("stdout")?;
+                limit -= 1;
             }
         } else {
             let handle = &mut io::stdout();


### PR DESCRIPTION
This PR adds a simple option to specify the number of directories to output in `zoxide query`.

This option is useful when you only want to peek what the matching directories look like without listing them all. I'm currently expecting to use it in a hand-crafted fish completion script.

I currently write the completion script as:

```fish
complete -c z -x -a '(zoxide query -l -- $argv 2>/dev/null | head -n 20)'
```

The redirection is needed because otherwise you get a panic due to EPIPE. Now with this limit option I can just write:

```fish
complete -c z -x -a '(zoxide query -l -n 20 $argv)'
```

