### PR TITLE
New installer options (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ zoxide can be installed in 4 easy steps:
    > The recommended way to install zoxide is via the install script:
    >
    > ```sh
-   > curl -sS https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | bash
+   > curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh
    > ```
    >
    > Or, you can use a package manager:
@@ -128,7 +128,7 @@ zoxide can be installed in 4 easy steps:
    > Or, run this command in your terminal:
    >
    > ```sh
-   > curl -sS https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | bash
+   > curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh
    > ```
 
    </details>
@@ -154,7 +154,7 @@ zoxide can be installed in 4 easy steps:
    > If you're using Cygwin, Git Bash, or MSYS2, use the install script instead:
    >
    > ```sh
-   > curl -sS https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | bash
+   > curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh
    > ```
 
    </details>

--- a/install.sh
+++ b/install.sh
@@ -108,9 +108,9 @@ main() {
     # Install binary.
     # shellcheck disable=SC2086 # The lack of quoting is intentional. This may not be the best way to do it, but it's hard to properly do in POSIX
     {
-        ensure ${_sudo} mkdir -p "${_bin_dir}"
-        ensure ${_sudo} cp "${_bin_name}" "${_bin_dir}"
-        ensure ${_sudo} chmod +x "${_bin_dir}/${_bin_name}"
+        ensure ${_sudo} mkdir -p -- "${_bin_dir}"
+        ensure ${_sudo} cp -- "${_bin_name}" "${_bin_dir}"
+        ensure ${_sudo} chmod +x -- "${_bin_dir}/${_bin_name}"
     }
     echo "Installed zoxide to ${_bin_dir}"
 
@@ -130,8 +130,8 @@ main() {
     # Install manpages.
     # shellcheck disable=SC2086 # The lack of quoting is intentional.
     {
-        ensure ${_sudo} mkdir -p "${_man_dir}/man1"
-        ensure ${_sudo} cp "man/man1/"* "${_man_dir}/man1/"
+        ensure ${_sudo} mkdir -p -- "${_man_dir}/man1"
+        ensure ${_sudo} cp -- "man/man1/"* "${_man_dir}/man1/"
     }
     echo "Installed manpages to ${_man_dir}"
 
@@ -169,7 +169,7 @@ download_zoxide() {
         err "you have exceeded GitHub's API rate limit. Please try again later, or use a different installation method: https://github.com/ajeetdsouza/zoxide/#installation"
 
     local _package_url
-    _package_url="$(echo "${_releases}" | grep "browser_download_url" | cut -d '"' -f 4 | grep "${_arch}")" ||
+    _package_url="$(echo "${_releases}" | grep "browser_download_url" | cut -d '"' -f 4 | grep -- "${_arch}")" ||
         err "zoxide has not yet been packaged for your architecture (${_arch}), please file an issue: https://github.com/ajeetdsouza/zoxide/issues"
 
     local _ext
@@ -437,7 +437,7 @@ need_cmd() {
 }
 
 check_cmd() {
-    command -v "$1" >/dev/null 2>&1
+    command -v -- "$1" >/dev/null 2>&1
 }
 
 # Run a command that should never fail. If the command fails execution
@@ -477,8 +477,8 @@ test_writeable() {
         return 1 # an empty path should never be writeable
     fi
     path="$1/test.txt"
-    if touch "${path}" 2>/dev/null; then
-        rm "${path}"
+    if touch -- "${path}" 2>/dev/null; then
+        rm -- "${path}"
         return 0
     else
         return 1

--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,13 @@ main() {
         # subtle ways later on:
         err 'the installer does not work with this ksh93 version; please try bash'
     fi
+    # from posix `command -v` definition (https://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html):
+    # "Shell functions, special built-in utilities, regular built-in utilities not associated with a PATH search, and shell reserved words shall be written as just their names."
+    if [ "$(command -v -- local)" != "local" ]; then
+        # Local is not a posix defined builtin, so it may not be available.
+        # Print a message rather than fail in subtle ways later on:
+        err "the installer does not work with this shell; please try bash"
+    fi
 
     set -u
 

--- a/install.sh
+++ b/install.sh
@@ -37,13 +37,12 @@ main() {
     local _bin_dir="${HOME}/.local/bin"
     local _bin_name
     local _man_dir="${HOME}/.local/share/man"
-    local _sudo="sudo"
+    local _sudo
 
     parse_args "$@" # sets global variables (BIN_DIR, MAN_DIR, ARCH, SUDO)
 
     _bin_dir=${BIN_DIR:-$_bin_dir}
     _man_dir=${MAN_DIR:-$_man_dir}
-    _sudo=${SUDO:-$_sudo}
 
     if [ -n "${ARCH:-}" ]; then
         # if the user specifed, trust them - don't error on unrecognized hardware.
@@ -66,6 +65,7 @@ main() {
         _sudo=''
     else
         echo "Escalated permissions are required to install to ${_bin_dir}"
+        _sudo=${SUDO:-"sudo"}
         if [ "${_sudo}" = 'sudo' ]; then
             elevate_priv # only check if the user didn't provide it, blindly trust user provided values
         fi
@@ -106,6 +106,19 @@ main() {
         ensure ${_sudo} chmod +x "${_bin_dir}/${_bin_name}"
     }
     echo "Installed zoxide to ${_bin_dir}"
+
+    if test_writeable "${_man_dir}"; then
+        echo "Installing zoxide man pages, please wait…"
+        _sudo=""
+    else
+        echo "Escalated permissions are required to install man pages to ${_man_dir}"
+        _sudo=${SUDO:-"sudo"}
+        if [ "${_sudo}" = 'sudo' ]; then
+            elevate_priv # only check if the user didn't provide it, blindly trust user provided values
+        fi
+        echo "Installing zoxide man pages as root, please wait…"
+    fi
+
 
     # Install manpages.
     # shellcheck disable=SC2086 # The lack of quoting is intentional.

--- a/install.sh
+++ b/install.sh
@@ -16,11 +16,6 @@ main() {
 
     set -u
 
-    # local is not a POSIX builtin, so it may not be available.
-    if [ "$(command -v -- local 2>/dev/null || true)" != "local" ]; then
-        err 'the installer does not work with this shell; please try bash'
-    fi
-
     parse_args "$@"
 
     local _arch

--- a/install.sh
+++ b/install.sh
@@ -12,17 +12,17 @@
 usage() {
     # Note: here-docs aren't defined in posix
     printf '%s\n' \
-"Usage: install.sh [option]" \
-"Fetch and install the latest version of zoxide, if zoxide is already" \
-"installed it will be updated to the latest version." \
-"" \
-"Options:" \
-"  -b, --bin-dir   Override the bin installation directory [default: ${_bin_dir}]" \
-"  -m, --man-dir   Override the man installation directory [default: ${_man_dir}]" \
-"  -a, --arch      Override the architecture identified by the installer" \
-"  -s, --sudo      Override the command used to elevate to root privaliges [default: sudo]" \
-"  -h, --help      Display this help message" \
-    || true
+        "Usage: install.sh [option]" \
+        "Fetch and install the latest version of zoxide, if zoxide is already" \
+        "installed it will be updated to the latest version." \
+        "" \
+        "Options:" \
+        "  -b, --bin-dir   Override the bin installation directory [default: ${_bin_dir}]" \
+        "  -m, --man-dir   Override the man installation directory [default: ${_man_dir}]" \
+        "  -a, --arch      Override the architecture identified by the installer" \
+        "  -s, --sudo      Override the command used to elevate to root privaliges [default: sudo]" \
+        "  -h, --help      Display this help message" ||
+        true
 }
 
 main() {
@@ -64,8 +64,8 @@ main() {
 
     local _bin_name
     case "${_arch}" in
-        *windows*) _bin_name="zoxide.exe" ;;
-        *) _bin_name="zoxide" ;;
+    *windows*) _bin_name="zoxide.exe" ;;
+    *) _bin_name="zoxide" ;;
     esac
 
     local _sudo
@@ -80,8 +80,6 @@ main() {
         fi
         echo "Installing zoxide as root, please wait…"
     fi
-
-
 
     # Create and enter a temporary directory.
     local _tmp_dir
@@ -128,7 +126,6 @@ main() {
         echo "Installing zoxide man pages as root, please wait…"
     fi
 
-
     # Install manpages.
     # shellcheck disable=SC2086 # The lack of quoting is intentional.
     {
@@ -136,7 +133,6 @@ main() {
         ensure ${_sudo} cp -- "man/man1/"* "${_man_dir}/man1/"
     }
     echo "Installed manpages to ${_man_dir}"
-
 
     # Print success message and check $PATH.
     echo ""
@@ -460,17 +456,16 @@ err() {
 
 elevate_priv() {
     if ! check_cmd sudo; then
-        echo  'Could not find the command "sudo", needed to get permissions for install.' >&2
-        echo  "If you are on Windows, please run your shell as an administrator, then" >&2
-        echo  "rerun this script. Otherwise, please run this script as root, or install" >&2
-        echo  "sudo." >&2
+        echo 'Could not find the command "sudo", needed to get permissions for install.' >&2
+        echo "If you are on Windows, please run your shell as an administrator, then" >&2
+        echo "rerun this script. Otherwise, please run this script as root, or install" >&2
+        echo "sudo." >&2
         exit 1
     fi
     if ! sudo -v; then
         err "Superuser not granted, aborting installation"
     fi
 }
-
 
 # Test if a location is writeable by trying to write to it. Windows does not let
 # you test writeability other than by writing: https://stackoverflow.com/q/1999988
@@ -487,56 +482,24 @@ test_writeable() {
     fi
 }
 
-
 # parse the arguments passed and set the environment variables accordingly
 parse_args() {
     # parse argv variables
     while [ "$#" -gt 0 ]; do
         case "$1" in
-            -b | --bin-dir)
-                BIN_DIR="$2"
-                shift 2
-                ;;
-            -m | --man-dir)
-                MAN_DIR="$2"
-                shift 2
-                ;;
-            -a | --arch)
-                ARCH="$2"
-                shift 2
-                ;;
-            -s | --sudo)
-                SUDO="$2"
-                shift 2
-                ;;
-            -h | --help)
-                usage
-                exit 0
-                ;;
-
-            -b=* | --bin-dir=*)
-                BIN_DIR="${1#*=}"
-                shift 1
-                ;;
-            -m=* | --man-dir=*)
-                MAN_DIR="${1#*=}"
-                shift 1
-                ;;
-            -a=* | --arch=*)
-                ARCH="${1#*=}"
-                shift 1
-                ;;
-            -s=* | --sudo=*)
-                SUDO="${1#*=}"
-                shift 1
-                ;;
-            *)
-                err "Unknown option: $1"
-                ;;
+        -b | --bin-dir) BIN_DIR="$2" && shift 2 ;;
+        -m | --man-dir) MAN_DIR="$2" && shift 2 ;;
+        -a | --arch) ARCH="$2" && shift 2 ;;
+        -s | --sudo) SUDO="$2" && shift 2 ;;
+        -h | --help) usage && exit 0 ;;
+        -b=* | --bin-dir=*) BIN_DIR="${1#*=}" && shift 1 ;;
+        -m=* | --man-dir=*) MAN_DIR="${1#*=}" && shift 1 ;;
+        -a=* | --arch=*) ARCH="${1#*=}" && shift 1 ;;
+        -s=* | --sudo=*) SUDO="${1#*=}" && shift 1 ;;
+        *) err "Unknown option: $1" ;;
         esac
     done
 }
-
 
 # This is put in braces to ensure that the script does not run until it is
 # downloaded completely.

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # shellcheck shell=dash
+# shellcheck enable=all # Show warnings in IDE - these are checked in CI
 # shellcheck disable=SC3043 # Assume `local` extension
 # vim:set ts=4 sw=4 et:
 
@@ -33,7 +34,7 @@ main() {
     fi
     # from posix `command -v` definition (https://pubs.opengroup.org/onlinepubs/9699919799/utilities/command.html):
     # "Shell functions, special built-in utilities, regular built-in utilities not associated with a PATH search, and shell reserved words shall be written as just their names."
-    if [ "$(command -v -- local)" != "local" ]; then
+    if [ "$(command -v -- local 2>/dev/null || true)" != "local" ]; then
         # Local is not a posix defined builtin, so it may not be available.
         # Print a message rather than fail in subtle ways later on:
         err "the installer does not work with this shell; please try bash"
@@ -47,8 +48,8 @@ main() {
 
     parse_args "$@" # sets global variables (BIN_DIR, MAN_DIR, ARCH, SUDO)
 
-    _bin_dir=${BIN_DIR:-$_bin_dir}
-    _man_dir=${MAN_DIR:-$_man_dir}
+    _bin_dir=${BIN_DIR:-${_bin_dir}}
+    _man_dir=${MAN_DIR:-${_man_dir}}
 
     if [ -n "${ARCH:-}" ]; then
         # if the user specifed, trust them - don't error on unrecognized hardware.
@@ -393,9 +394,9 @@ get_bitness() {
 }
 
 get_endianness() {
-    local cputype=$1
-    local suffix_eb=$2
-    local suffix_el=$3
+    local cputype="$1"
+    local suffix_eb="$2"
+    local suffix_el="$3"
 
     # detect endianness without od/hexdump, like get_bitness() does.
     need_cmd head

--- a/install.sh
+++ b/install.sh
@@ -466,7 +466,10 @@ elevate_priv() {
 # Test if a location is writeable by trying to write to it. Windows does not let
 # you test writeability other than by writing: https://stackoverflow.com/q/1999988
 test_writeable() {
-    path="${1:-}/test.txt"
+    if [ -z "${1-}" ]; then
+        return 1 # an empty path should never be writeable
+    fi
+    path="$1/test.txt"
     if touch "${path}" 2>/dev/null; then
         rm "${path}"
         return 0

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ usage() {
 "Options:" \
 "  -b, --bin-dir   Override the bin installation directory [default: ${_bin_dir}]" \
 "  -m, --man-dir   Override the man installation directory [default: ${_man_dir}]" \
-"  -a, --arch      Override the architecture identified by the installer [default: ${_arch}]" \
+"  -a, --arch      Override the architecture identified by the installer" \
 "  -s, --sudo      Override the command used to elevate to root privaliges [default: sudo]" \
 "  -h, --help      Display this help message" \
     || true
@@ -41,10 +41,9 @@ main() {
 
     set -u
 
+    # Note: these variables are used in the usage message!
     local _bin_dir="${HOME}/.local/bin"
-    local _bin_name
     local _man_dir="${HOME}/.local/share/man"
-    local _sudo
 
     parse_args "$@" # sets global variables (BIN_DIR, MAN_DIR, ARCH, SUDO)
 
@@ -62,11 +61,13 @@ main() {
     assert_nz "${_arch}" "arch"
     echo "Detected architecture: ${_arch}"
 
+    local _bin_name
     case "${_arch}" in
         *windows*) _bin_name="zoxide.exe" ;;
         *) _bin_name="zoxide" ;;
     esac
 
+    local _sudo
     if test_writeable "${_bin_dir}"; then
         echo "Installing zoxide, please wait…"
         _sudo=''


### PR DESCRIPTION
This is a rewrite of #590 to reduce the diff and make it a more reasonable pr.

Add support for options in install script

This adds support for serveral new command line options (taken from the usage):
    - `-b, --bin-dir   Override the bin installation directory`
    - `-m, --man-dir   Override the man installation directory`
    - `-a, --arch      Override the architecture identified by the installer`
    - `-h, --help      Display this help message`
This also (coincidentally) allows for $BIN_DIR, $MAN_DIR, and $ARCH to be set to create default settings for these.
These variables are *always* overwritten by the command line arguments.