### PR TITLE
fix command for powershell

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ zoxide can be installed in 4 easy steps:
    > `echo $profile` in PowerShell):
    >
    > ```powershell
-   > Invoke-Expression (& { (zoxide init powershell | Out-String) })
+   > Invoke-Expression (& { (zoxide init powershell --hook prompt | Out-String) })
    > ```
 
    </details>


### PR DESCRIPTION
the old command doesn't work and gives error

```
zoxide: PWD hooks are not supported below powershell 6.
        Use 'zoxide init powershell --hook prompt' instead.
At line:1 char:1
+ . 'C:\Users\aryan\Documents\WindowsPowerShell\Microsoft.PowerShell_pr ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,Microsoft.PowerShell_profile.ps1
```