### PR TITLE
Support nushell removal of spread operator

### DIFF
--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -44,7 +44,7 @@ def --env __zoxide_z [...rest:string] {
   let path = if (($rest | length) <= 1) and ($arg0 == '-' or ($arg0 | path expand | path type) == dir) {
     $arg0
   } else {
-    (zoxide query --exclude $env.PWD -- $rest | str trim -r -c "\n")
+    (zoxide query --exclude $env.PWD -- ...$rest | str trim -r -c "\n")
   }
   cd $path
 {%- if echo %}
@@ -54,7 +54,7 @@ def --env __zoxide_z [...rest:string] {
 
 # Jump to a directory using interactive search.
 def --env __zoxide_zi  [...rest:string] {
-  cd $'(zoxide query --interactive -- $rest | str trim -r -c "\n")'
+  cd $'(zoxide query --interactive -- ...$rest | str trim -r -c "\n")'
 {%- if echo %}
   echo $env.PWD
 {%- endif %}


### PR DESCRIPTION
Currently there is a warning that it will be removed starting from 0.90.1. Fixes #661