### PR TITLE
support autocd option

### DIFF
--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -75,6 +75,8 @@ function __zoxide_z() {
         __zoxide_cd "${OLDPWD}"
     elif [[ $# -eq 1 && -d $1 ]]; then
         __zoxide_cd "$1"
+    elif [[ $# -eq 2 && $1 == '--' ]]; then
+        __zoxide_cd "$2"
     elif [[ ${@: -1} == "${__zoxide_z_prefix}"?* ]]; then
         # shellcheck disable=SC2124
         \builtin local result="${@: -1}"
@@ -102,13 +104,7 @@ function __zoxide_zi() {
 
 \builtin unalias {{cmd}} &>/dev/null || \builtin true
 function {{cmd}}() {
-    if [[ $# -eq 2 && "$1" == "--" ]]; then
-        # This is how cd is called when bash's autocd option is set. To get the
-        # directory-changing behavior first argument must be skipped.
-        __zoxide_z "${@:2}"
-    else
-        __zoxide_z "$@"
-    fi
+    __zoxide_z "$@"
 }
 
 \builtin unalias {{cmd}}i &>/dev/null || \builtin true

--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -102,7 +102,7 @@ function __zoxide_zi() {
 
 \builtin unalias {{cmd}} &>/dev/null || \builtin true
 function {{cmd}}() {
-    if [[ $# -eq 2 && "$1" == "--" && -d $2 ]]; then
+    if [[ $# -eq 2 && "$1" == "--" ]]; then
         # This is how cd is called when bash's autocd option is set. To get the
         # directory-changing behavior first argument must be skipped.
         __zoxide_z "${@:2}"

--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -102,7 +102,13 @@ function __zoxide_zi() {
 
 \builtin unalias {{cmd}} &>/dev/null || \builtin true
 function {{cmd}}() {
-    __zoxide_z "$@"
+    if [[ $# -eq 2 && "$1" == "--" && -d $2 ]]; then
+        # This is how cd is called when bash's autocd option is set. To get the
+        # directory-changing behavior first argument must be skipped.
+        __zoxide_z "${@:2}"
+    else
+        __zoxide_z "$@"
+    fi
 }
 
 \builtin unalias {{cmd}}i &>/dev/null || \builtin true


### PR DESCRIPTION
In bash, when autocd option is set and user enters a directory name as a command, it results in a very specific call to cd:

cd -- [directory name]

zoxide's directory changing function passes all arguments to __zoxide_z as is, including the "--" first argument. By detecting this and skipping the first argument changing directory works with autocd set.

This particular bug only happens when initializing zoxide with `--cmd cd`. Here's how it breaks in bash:

```bash
$ shopt -c autocd
$ eval $(zoxide init --cmd cd bash)"
$ ..
cd -- ..
zoxide: no match found
```