### PR TITLE
fix: Space-Tab interactive completions repeating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- zsh: Space-Tab completion repeating output multiple times when matching single directory in history
 - fish: detect infinite loop when using `alias cd=z`.
 - fish / Nushell / PowerShell: handle queries that look like args (e.g. `z -x`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- zsh: Space-Tab completion repeating output multiple times when matching single directory in history
+- zsh: Space-Tab completion repeating output multiple times when matching single
+  directory
 - fish: detect infinite loop when using `alias cd=z`.
 - fish / Nushell / PowerShell: handle queries that look like args (e.g. `z -x`).
 

--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -119,6 +119,7 @@ if [[ -o zle ]]; then
         if [[ -n "${__zoxide_result}" ]]; then
             # shellcheck disable=SC2034,SC2296
             BUFFER="{{ cmd }} ${(q-)__zoxide_result}"
+            __zoxide_result=''
             \builtin zle reset-prompt
             \builtin zle accept-line
         else

--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -104,9 +104,12 @@ if [[ -o zle ]]; then
             # shellcheck disable=SC2086
             __zoxide_result="$(\command zoxide query --exclude "$(__zoxide_pwd || \builtin true)" --interactive -- ${words[2,-1]})" || __zoxide_result=''
 
+            # Set a result to ensure completion doesn't re-run
+            compadd -Q ""
+
             # Bind '\e[0n' to helper function.
             \builtin bindkey '\e[0n' '__zoxide_z_complete_helper'
-            # Send '\e[0n' to console input.
+            # Sends query device status code, which results in a '\e[0n' being sent to console input.
             \builtin printf '\e[5n'
         fi
 


### PR DESCRIPTION
Closes #780 and #775

Looks you needed to still call `compadd` to set a completion for the current function call, otherwise it kept trying to re-run the completion. 

This made it look like `Enter` wasn't accepting results in fzf (you could hit `Enter` 3 times and it would eventually work), and the single match repeated 3 times, as I suspect there is some completion retry if it fails, but didn't look for that answer.

I've left the clearing of the results in, as I think it might be good hygiene.
