### PR TITLE
feat(completion/zsh): list zoxide entries for corresponding options

### DIFF
--- a/contrib/completions/_zoxide
+++ b/contrib/completions/_zoxide
@@ -2,6 +2,16 @@
 
 autoload -U is-at-least
 
+__zoxide_list() {
+	local scored_list
+	local -a zoxide_list
+
+	scored_list="$(
+		zoxide query --list --score | sed -E 's/^\s+(\S+)\s+(.*)$/\2:\1/g')"
+	zoxide_list=("${(@f)scored_list}")
+	_describe -t paths 'zoxide entries' zoxide_list
+}
+
 _zoxide() {
     typeset -A opt_args
     typeset -a _arguments_options
@@ -59,7 +69,7 @@ _arguments "${_arguments_options[@]}" \
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-':path:' \
+':path:__zoxide_list' \
 && ret=0
 ;;
 (delete)
@@ -68,7 +78,7 @@ _arguments "${_arguments_options[@]}" \
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-':path:' \
+':path:__zoxide_list' \
 && ret=0
 ;;
 (increment)
@@ -77,7 +87,7 @@ _arguments "${_arguments_options[@]}" \
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-':path:' \
+':path:__zoxide_list' \
 && ret=0
 ;;
 (reload)
@@ -139,7 +149,7 @@ _arguments "${_arguments_options[@]}" \
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-'*::paths:_files -/' \
+'*::paths:__zoxide_list' \
 && ret=0
 ;;
         esac


### PR DESCRIPTION
List result of `zoxide query --list --score` as completion for corresponding options.