### PR TITLE
README.md - refer to man pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ zoxide works on all major shells.
 [Getting started](#getting-started) •
 [Installation](#installation) •
 [Configuration](#configuration) •
+[Usage](#usage) •
 [Integrations](#third-party-integrations)
 
 </div>
@@ -426,6 +427,18 @@ Environment variables[^2] can be used for configuration. They must be set before
 - `_ZO_RESOLVE_SYMLINKS`
   - When set to 1, `z` will resolve symlinks before adding directories to the
     database.
+
+## Usage
+
+Zoxide uses [man pages](https://en.wikipedia.org/wiki/Man_page) for its documentation. To see them:
+
+```shell
+man zoxide
+# For the subcommands
+man zoxide-query
+```
+
+You can find [these man pages online](https://www.mankier.com/1/zoxide) too.
 
 ## Third-party integrations
 

--- a/README.md
+++ b/README.md
@@ -430,7 +430,8 @@ Environment variables[^2] can be used for configuration. They must be set before
 
 ## Usage
 
-Zoxide uses [man pages](https://en.wikipedia.org/wiki/Man_page) for its documentation. To see them:
+Zoxide uses [man pages](https://en.wikipedia.org/wiki/Man_page) for its
+documentation. To see them:
 
 ```shell
 man zoxide


### PR DESCRIPTION
Not everybody's first instinct is to `man zoxide` so let's be explicit.