### PR TITLE
fix(elvish): before-chdir should assign to oldpwd upvalue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fish: detect infinite loop when using `alias cd=z`.
 - fish / Nushell / PowerShell: handle queries that look like args (e.g. `z -x`).
 - zsh: better cd completions.
+- elvish: `z -` now work as expected.
 - Lazily delete excluded directories from the database.
 
 ## [0.9.4] - 2024-02-21

--- a/templates/elvish.txt
+++ b/templates/elvish.txt
@@ -22,7 +22,7 @@ fn __zoxide_cd {|path|
 
 # Initialize hook to track previous directory.
 var oldpwd = $builtin:pwd
-set builtin:before-chdir = [$@builtin:before-chdir {|_| edit:add-var oldpwd $builtin:pwd }]
+set builtin:before-chdir = [$@builtin:before-chdir {|_| set oldpwd = $builtin:pwd }]
 
 # Initialize hook to add directories to zoxide.
 {%- if hook == InitHook::None %}


### PR DESCRIPTION
elvish uses lexical scoping for closure capture, as such all `oldpwd` references within the script refers to the `oldpwd` defined at the top. However, before-chdir hook is trying to assign to `oldpwd` within the editor scope, which is not used by this script.

This manifested as a bug in which:

```
~
> mkdir -p /tmp/another

~
> z /tmp

/tmp
> z another

/tmp/another
> z -

~
> # The previous dir should be /tmp not ~!
```

Because the hook was updating a variable that was not used.

This PR fixes the hook so that before-chdir assign to the proper upvalue.