### PR TITLE
Updated Nushell script for 0.94.0

### DIFF
--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -41,7 +41,8 @@ if (not ($env | default false __zoxide_hooked | get __zoxide_hooked)) {
 # Jump to a directory using only keywords.
 def --env --wrapped __zoxide_z [...rest:string] {
   let arg0 = ($rest | append '~').0
-  let path = if (($rest | length) <= 1) and ($arg0 == '-' or ($arg0 | path expand | path type) == dir) {
+  let arg0_is_dir = (try {$arg0 | path expand | path type}) == 'dir'
+  let path = if (($rest | length) <= 1) and ($arg0 == '-' or $arg0_is_dir) {
     $arg0
   } else {
     (zoxide query --exclude $env.PWD -- ...$rest | str trim -r -c "\n")


### PR DESCRIPTION
Nushell 0.94.0 broke zoxide because of [this PR](https://github.com/nushell/nushell/pull/12975) that changed the behavior of `path type` to error out when the path doesn't exist.

I wrapped the `path type` call in a `try` block and `z` works again now. It should still work for older Nushell versions as well.