### PR TITLE
Enhancement: Support min_score in queries

### DIFF
--- a/contrib/completions/_zoxide
+++ b/contrib/completions/_zoxide
@@ -117,6 +117,8 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (query)
 _arguments "${_arguments_options[@]}" \
+'-m+[Exclude below a certain score]:MIN_SCORE: ' \
+'--min-score=[Exclude below a certain score]:MIN_SCORE: ' \
 '--exclude=[Exclude the current directory]:path:_files -/' \
 '-a[Show unavailable directories]' \
 '--all[Show unavailable directories]' \

--- a/contrib/completions/_zoxide.ps1
+++ b/contrib/completions/_zoxide.ps1
@@ -99,6 +99,8 @@ Register-ArgumentCompleter -Native -CommandName 'zoxide' -ScriptBlock {
             break
         }
         'zoxide;query' {
+            [CompletionResult]::new('-m', 'm', [CompletionResultType]::ParameterName, 'Exclude below a certain score')
+            [CompletionResult]::new('--min-score', 'min-score', [CompletionResultType]::ParameterName, 'Exclude below a certain score')
             [CompletionResult]::new('--exclude', 'exclude', [CompletionResultType]::ParameterName, 'Exclude the current directory')
             [CompletionResult]::new('-a', 'a', [CompletionResultType]::ParameterName, 'Show unavailable directories')
             [CompletionResult]::new('--all', 'all', [CompletionResultType]::ParameterName, 'Show unavailable directories')

--- a/contrib/completions/zoxide.bash
+++ b/contrib/completions/zoxide.bash
@@ -187,12 +187,20 @@ _zoxide() {
             return 0
             ;;
         zoxide__query)
-            opts="-a -i -l -s -h -V --all --interactive --list --score --exclude --help --version [KEYWORDS]..."
+            opts="-a -i -l -s -m -h -V --all --interactive --list --score --min-score --exclude --help --version [KEYWORDS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --min-score)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -m)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --exclude)
                     COMPREPLY=()
                     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then

--- a/contrib/completions/zoxide.elv
+++ b/contrib/completions/zoxide.elv
@@ -87,6 +87,8 @@ set edit:completion:arg-completer[zoxide] = {|@words|
             cand --version 'Print version'
         }
         &'zoxide;query'= {
+            cand -m 'Exclude below a certain score'
+            cand --min-score 'Exclude below a certain score'
             cand --exclude 'Exclude the current directory'
             cand -a 'Show unavailable directories'
             cand --all 'Show unavailable directories'

--- a/contrib/completions/zoxide.fish
+++ b/contrib/completions/zoxide.fish
@@ -31,6 +31,7 @@ complete -c zoxide -n "__fish_seen_subcommand_from init" -l hook -d 'Changes how
 complete -c zoxide -n "__fish_seen_subcommand_from init" -l no-cmd -d 'Prevents zoxide from defining the `z` and `zi` commands'
 complete -c zoxide -n "__fish_seen_subcommand_from init" -s h -l help -d 'Print help'
 complete -c zoxide -n "__fish_seen_subcommand_from init" -s V -l version -d 'Print version'
+complete -c zoxide -n "__fish_seen_subcommand_from query" -s m -l min-score -d 'Exclude below a certain score' -r
 complete -c zoxide -n "__fish_seen_subcommand_from query" -l exclude -d 'Exclude the current directory' -r -f -a "(__fish_complete_directories)"
 complete -c zoxide -n "__fish_seen_subcommand_from query" -s a -l all -d 'Show unavailable directories'
 complete -c zoxide -n "__fish_seen_subcommand_from query" -s i -l interactive -d 'Use interactive selection'

--- a/contrib/completions/zoxide.ts
+++ b/contrib/completions/zoxide.ts
@@ -195,6 +195,15 @@ const completion: Fig.Spec = {
       description: "Search for a directory in the database",
       options: [
         {
+          name: ["-m", "--min-score"],
+          description: "Exclude below a certain score",
+          isRepeatable: true,
+          args: {
+            name: "min_score",
+            isOptional: true,
+          },
+        },
+        {
           name: "--exclude",
           description: "Exclude the current directory",
           isRepeatable: true,

--- a/src/cmd/cmd.rs
+++ b/src/cmd/cmd.rs
@@ -169,6 +169,10 @@ pub struct Query {
     #[clap(long, short)]
     pub score: bool,
 
+    /// Exclude below a certain score
+    #[clap(long, short)]
+    pub min_score: Option<f64>,
+
     /// Exclude the current directory
     #[clap(long, value_hint = ValueHint::DirPath, value_name = "path")]
     pub exclude: Option<String>,

--- a/src/cmd/query.rs
+++ b/src/cmd/query.rs
@@ -37,7 +37,7 @@ impl Query {
                 Some(dir)
                     if self.min_score.is_some() && dir.score(now) < self.min_score.unwrap() =>
                 {
-                    continue
+                    continue;
                 }
                 Some(dir) => {
                     if let Some(selection) = fzf.write(dir, now)? {

--- a/src/cmd/query.rs
+++ b/src/cmd/query.rs
@@ -34,6 +34,11 @@ impl Query {
         let selection = loop {
             match stream.next() {
                 Some(dir) if Some(dir.path.as_ref()) == self.exclude.as_deref() => continue,
+                Some(dir)
+                    if self.min_score.is_some() && dir.score(now) < self.min_score.unwrap() =>
+                {
+                    continue
+                }
                 Some(dir) => {
                     if let Some(selection) = fzf.write(dir, now)? {
                         break selection;
@@ -57,6 +62,11 @@ impl Query {
         while let Some(dir) = stream.next() {
             if Some(dir.path.as_ref()) == self.exclude.as_deref() {
                 continue;
+            }
+            if let Some(min_score) = self.min_score {
+                if dir.score(now) < min_score {
+                    continue;
+                }
             }
             let dir = if self.score { dir.display().with_score(now) } else { dir.display() };
             writeln!(handle, "{dir}").pipe_exit("stdout")?;


### PR DESCRIPTION
This PR adds the `-m` flag to queries, allowing a user to specify directories to be discarded if they fall below a given threshold. Works both interactively and in list mode

Example usage
```bash
$ zoxide query -lsm4

$ zoxide query -im4
```