### PR TITLE
cmd/query: Add `--sort-by` option

### DIFF
--- a/contrib/completions/_zoxide
+++ b/contrib/completions/_zoxide
@@ -117,6 +117,7 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (query)
 _arguments "${_arguments_options[@]}" \
+'--sort-by=[Sort result]:SORT_BY:(path score last-accessed)' \
 '--exclude=[Exclude the current directory]:path:_files -/' \
 '-a[Show unavailable directories]' \
 '--all[Show unavailable directories]' \

--- a/contrib/completions/_zoxide.ps1
+++ b/contrib/completions/_zoxide.ps1
@@ -99,6 +99,7 @@ Register-ArgumentCompleter -Native -CommandName 'zoxide' -ScriptBlock {
             break
         }
         'zoxide;query' {
+            [CompletionResult]::new('--sort-by', 'sort-by', [CompletionResultType]::ParameterName, 'Sort result')
             [CompletionResult]::new('--exclude', 'exclude', [CompletionResultType]::ParameterName, 'Exclude the current directory')
             [CompletionResult]::new('-a', 'a', [CompletionResultType]::ParameterName, 'Show unavailable directories')
             [CompletionResult]::new('--all', 'all', [CompletionResultType]::ParameterName, 'Show unavailable directories')

--- a/contrib/completions/zoxide.bash
+++ b/contrib/completions/zoxide.bash
@@ -187,12 +187,16 @@ _zoxide() {
             return 0
             ;;
         zoxide__query)
-            opts="-a -i -l -s -h -V --all --interactive --list --score --exclude --help --version [KEYWORDS]..."
+            opts="-a -i -l -s -h -V --all --interactive --list --sort-by --score --exclude --help --version [KEYWORDS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --sort-by)
+                    COMPREPLY=($(compgen -W "path score last-accessed" -- "${cur}"))
+                    return 0
+                    ;;
                 --exclude)
                     COMPREPLY=()
                     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then

--- a/contrib/completions/zoxide.elv
+++ b/contrib/completions/zoxide.elv
@@ -87,6 +87,7 @@ set edit:completion:arg-completer[zoxide] = {|@words|
             cand --version 'Print version'
         }
         &'zoxide;query'= {
+            cand --sort-by 'Sort result'
             cand --exclude 'Exclude the current directory'
             cand -a 'Show unavailable directories'
             cand --all 'Show unavailable directories'

--- a/contrib/completions/zoxide.fish
+++ b/contrib/completions/zoxide.fish
@@ -31,6 +31,7 @@ complete -c zoxide -n "__fish_seen_subcommand_from init" -l hook -d 'Changes how
 complete -c zoxide -n "__fish_seen_subcommand_from init" -l no-cmd -d 'Prevents zoxide from defining the `z` and `zi` commands'
 complete -c zoxide -n "__fish_seen_subcommand_from init" -s h -l help -d 'Print help'
 complete -c zoxide -n "__fish_seen_subcommand_from init" -s V -l version -d 'Print version'
+complete -c zoxide -n "__fish_seen_subcommand_from query" -l sort-by -d 'Sort result' -r -f -a "{path	'',score	'',last-accessed	''}"
 complete -c zoxide -n "__fish_seen_subcommand_from query" -l exclude -d 'Exclude the current directory' -r -f -a "(__fish_complete_directories)"
 complete -c zoxide -n "__fish_seen_subcommand_from query" -s a -l all -d 'Show unavailable directories'
 complete -c zoxide -n "__fish_seen_subcommand_from query" -s i -l interactive -d 'Use interactive selection'

--- a/contrib/completions/zoxide.ts
+++ b/contrib/completions/zoxide.ts
@@ -195,6 +195,20 @@ const completion: Fig.Spec = {
       description: "Search for a directory in the database",
       options: [
         {
+          name: "--sort-by",
+          description: "Sort result",
+          isRepeatable: true,
+          args: {
+            name: "sort_by",
+            isOptional: true,
+            suggestions: [
+              "path",
+              "score",
+              "last-accessed",
+            ],
+          },
+        },
+        {
           name: "--exclude",
           description: "Exclude the current directory",
           isRepeatable: true,

--- a/src/cmd/cmd.rs
+++ b/src/cmd/cmd.rs
@@ -165,6 +165,10 @@ pub struct Query {
     #[clap(long, short, conflicts_with = "interactive")]
     pub list: bool,
 
+    /// Sort result
+    #[clap(long)]
+    pub sort_by: Option<Ordering>,
+
     /// Print score with results
     #[clap(long, short)]
     pub score: bool,
@@ -172,6 +176,13 @@ pub struct Query {
     /// Exclude the current directory
     #[clap(long, value_hint = ValueHint::DirPath, value_name = "path")]
     pub exclude: Option<String>,
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy)]
+pub enum Ordering {
+    Path,
+    Score,
+    LastAccessed,
 }
 
 /// Remove a directory from the database

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -178,6 +178,15 @@ impl Database {
         self.with_dirty_mut(|dirty| *dirty = true);
     }
 
+    pub fn sort_by_last_accessed(&mut self) {
+        self.with_dirs_mut(|dirs| {
+            dirs.sort_unstable_by(|dir1: &Dir, dir2: &Dir| {
+                dir1.last_accessed.cmp(&dir2.last_accessed)
+            })
+        });
+        self.with_dirty_mut(|dirty| *dirty = true);
+    }
+
     pub fn dirty(&self) -> bool {
         *self.borrow_dirty()
     }


### PR DESCRIPTION
Added the option `--sort-by [score|path|last-accessed]` for the `query` subcommand with default value `score` i.e:

```bash
$ zoxide query --list --score --sort-by last-accessed
   4.0 /home/martin/playground/scala/scala-3-project-template
   3.5 /home/martin/playground/rust
   3.8 /home/martin/playground/python
  12.0 /home/martin/projects/zoxide
  11.8 /home/martin/playground
  16.5 /home/martin/projects/thesis
   6.0 /home/martin/projects/thesis/frontend
...
```

```bash
$ zoxide query --list --score --sort-by path
   0.2 /home/martin/.local/state
   0.2 /home/martin/.local/share/zoxide
   0.2 /home/martin/.local/share
   0.2 /home/martin/.config/protonmail/bridge-v3
   0.2 /home/martin/.config/protonmail
   0.5 /home
   0.5 /etc/nixos/lib/lisp
   0.8 /
...
```

```bash
$ zoxide query --list --score
  16.5 /home/martin/projects/thesis
  16.0 /home/martin/projects/zoxide
   8.0 /home/martin/projects/egcd
   8.0 /persist
   6.0 /home/martin/projects/thesis/frontend
...
```

Fixes #784 as well as #815.