### PR TITLE
Support `z -- <dir>` for zsh and fish

### DIFF
--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -82,6 +82,8 @@ function __zoxide_z
         __zoxide_cd -
     else if test $argc -eq 1 -a -d $argv[1]
         __zoxide_cd $argv[1]
+    else if test $argc -eq 2 -a $argv[1] = --
+        __zoxide_cd -- $argv[2]
     else if set -l result (string replace --regex -- $__zoxide_z_prefix_regex '' $argv[-1]); and test -n $result
         __zoxide_cd $result
     else

--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -59,6 +59,8 @@ function __zoxide_z() {
         __zoxide_cd ~
     elif [[ "$#" -eq 1 ]] && { [[ -d "$1" ]] || [[ "$1" = '-' ]] || [[ "$1" =~ ^[-+][0-9]$ ]]; }; then
         __zoxide_cd "$1"
+    elif [[ "$#" -eq 2 ]] && [[ "$1" = "--" ]]; then
+        __zoxide_cd "$2"
     else
         \builtin local result
         # shellcheck disable=SC2312


### PR DESCRIPTION
Inspired by @solodov https://github.com/ajeetdsouza/zoxide/pull/695, and @LangLangBart https://github.com/junegunn/fzf/pull/3928#issuecomment-2233072195, this PR ports the support for `z -- <dir>` to zsh and fish shell.

This enhancement will provide better compatibility with the `cd` command. With this change, the syntax `cd -- <dir>` will continue to function correctly when zoxide overrides the built-in cd using `--cmd cd`. This also fixes https://github.com/junegunn/fzf/pull/2799 [^1] where fzf uses `cd -- <dir>` in the Alt+C key-binding.

[^1]: The PR to fzf which use `builtin cd -- <dir>` to avoid conflict is reverted. See [fzf#3928](https://github.com/junegunn/fzf/pull/3928)