### PR TITLE
fix(fish): prefix builtin for all non-reserved words

### DIFF
--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -71,11 +71,11 @@ end
 if test -z $__zoxide_z_prefix
     set __zoxide_z_prefix 'z!'
 end
-set __zoxide_z_prefix_regex ^(string escape --style=regex $__zoxide_z_prefix)
+set __zoxide_z_prefix_regex ^(string escape --style=regex -- $__zoxide_z_prefix)
 
 # Jump to a directory using only keywords.
 function __zoxide_z
-    set -l argc (count $argv)
+    set -l argc (builtin count $argv)
     if test $argc -eq 0
         __zoxide_cd $HOME
     else if test "$argv" = -
@@ -94,19 +94,19 @@ end
 
 # Completions.
 function __zoxide_z_complete
-    set -l tokens (commandline --current-process --tokenize)
-    set -l curr_tokens (commandline --cut-at-cursor --current-process --tokenize)
+    set -l tokens (builtin commandline --current-process --tokenize)
+    set -l curr_tokens (builtin commandline --cut-at-cursor --current-process --tokenize)
 
-    if test (count $tokens) -le 2 -a (count $curr_tokens) -eq 1
+    if test (builtin count $tokens) -le 2 -a (builtin count $curr_tokens) -eq 1
         # If there are < 2 arguments, use `cd` completions.
-        complete --do-complete "'' "(commandline --cut-at-cursor --current-token) | string match --regex '.*/$'
-    else if test (count $tokens) -eq (count $curr_tokens); and ! string match --quiet --regex $__zoxide_z_prefix_regex. $tokens[-1]
+        complete --do-complete "'' "(builtin commandline --cut-at-cursor --current-token) | string match --regex -- '.*/$'
+    else if test (builtin count $tokens) -eq (builtin count $curr_tokens); and ! string match --quiet --regex -- $__zoxide_z_prefix_regex. $tokens[-1]
         # If the last argument is empty and the one before doesn't start with
         # $__zoxide_z_prefix, use interactive selection.
         set -l query $tokens[2..-1]
-        set -l result (zoxide query --exclude (__zoxide_pwd) --interactive -- $query)
-        and echo $__zoxide_z_prefix$result
-        commandline --function repaint
+        set -l result (command zoxide query --exclude (__zoxide_pwd) --interactive -- $query)
+        and builtin echo $__zoxide_z_prefix$result
+        builtin commandline --function repaint
     end
 end
 complete --command __zoxide_z --no-files --arguments '(__zoxide_z_complete)'
@@ -124,10 +124,10 @@ end
 {%- match cmd %}
 {%- when Some with (cmd) %}
 
-abbr --erase {{cmd}} &>/dev/null
+builtin abbr --erase {{cmd}} &>/dev/null
 alias {{cmd}}=__zoxide_z
 
-abbr --erase {{cmd}}i &>/dev/null
+builtin abbr --erase {{cmd}}i &>/dev/null
 alias {{cmd}}i=__zoxide_zi
 
 {%- when None %}


### PR DESCRIPTION
There are a few builtins used here are not documented as reserved words (https://fishshell.com/docs/current/cmds/function.html#description).

They are possible to be overrided by user functions, while we may depend on its default behavior.
