### PR TITLE
fix(fish): reset status code before `set`

### DIFF
--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -84,7 +84,9 @@ function __zoxide_z
         __zoxide_cd $argv[1]
     else if test $argc -eq 2 -a $argv[1] = --
         __zoxide_cd -- $argv[2]
-    else if set -l result (string replace --regex -- $__zoxide_z_prefix_regex '' $argv[-1]); and test -n $result
+    else if true; and set -l result (string replace --regex -- $__zoxide_z_prefix_regex '' $argv[-1]); and test -n $result
+        # `set` will preserve the exit status of the last command
+        # https://github.com/fish-shell/fish-shell/issues/3651
         __zoxide_cd $result
     else
         set -l result (command zoxide query --exclude (__zoxide_pwd) -- $argv)


### PR DESCRIPTION
`set` will preserve the exit status of the last command (https://github.com/fish-shell/fish-shell/issues/3651).
