### PR TITLE
Fix issues with PowerShell env variables

### DIFF
--- a/templates/powershell.txt
+++ b/templates/powershell.txt
@@ -27,6 +27,7 @@ function global:__zoxide_pwd {
 
 # cd + custom logic based on the value of _ZO_ECHO.
 function global:__zoxide_cd($dir, $literal) {
+    $dir = [System.Environment]::ExpandEnvironmentVariables($dir)
     $dir = if ($literal) {
         Set-Location -LiteralPath $dir -Passthru -ErrorAction Stop
     } else {
@@ -106,8 +107,8 @@ function global:__zoxide_z {
     elseif ($args.Length -eq 1 -and ($args[0] -eq '-' -or $args[0] -eq '+')) {
         __zoxide_cd $args[0] $false
     }
-    elseif ($args.Length -eq 1 -and (Test-Path $args[0] -PathType Container)) {
-        __zoxide_cd $args[0] $true
+    elseif ($args.Length -eq 1 -and (Test-Path ([System.Environment]::ExpandEnvironmentVariables($args[0])) -PathType Container)) {
+        __zoxide_cd ([System.Environment]::ExpandEnvironmentVariables($args[0])) $true
     }
     else {
         $result = __zoxide_pwd


### PR DESCRIPTION
Fixes #906.

`$dir` is expanded using `ExpandEnvironmentStrings` if there is any environment variables.

Tested on my machine (Windows 11, PowerShell 5.1 build 22621) and it works fine.