### PR TITLE
Improve nushell template to gracefully handle no match errors

### DIFF
--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -51,7 +51,10 @@ def --env --wrapped __zoxide_z [...rest:string] {
         "" 
     })
   }
-  cd $path
+
+  if $path != "" {
+    cd $path
+  }
 {%- if echo %}
   echo $env.PWD
 {%- endif %}

--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -48,7 +48,7 @@ def --env --wrapped __zoxide_z [...rest:string] {
     (try {
       zoxide query --exclude $env.PWD -- ...$rest | str trim -r -c "\n"
     } catch {
-        "" 
+        ""
     })
   }
 

--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -45,7 +45,11 @@ def --env --wrapped __zoxide_z [...rest:string] {
   let path = if (($rest | length) <= 1) and ($arg0 == '-' or $arg0_is_dir) {
     $arg0
   } else {
-    (zoxide query --exclude $env.PWD -- ...$rest | str trim -r -c "\n")
+    (try {
+      zoxide query --exclude $env.PWD -- ...$rest | str trim -r -c "\n"
+    } catch {
+        "" 
+    })
   }
   cd $path
 {%- if echo %}


### PR DESCRIPTION
Currently, the `__zoxide_z` command in nushell throws the following error when no matches are found for a query:
```shell
zoxide: no match found
Error: nu::shell::non_zero_exit_code

  × External command had a non-zero exit code
    ╭─[/home/marcel/.config/nushell/external/zoxide.nu:33:8]
 32 │   
 33 │       (zoxide query --exclude $env.PWD -- ...$rest | str trim -r -c "\n")
    ·        ───┬──
    ·           ╰── exited with code 1
 34 │     
    ╰────
```

when the behavior in any other shell is to only return the result of the zoxide command:
```shell
zoxide: no match found
```

This PR modifies the nushell template to ignore errors and display only the `zoxide query` command result. The cd command is executed only when a valid path is found.