### PR TITLE
Add support for case-sensitive queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- `$_ZO_CASE_SENSITIVITY` to support case-sensitive querying in addition to the
+  default case-insensitive querying.
+
 ## [0.9.8] - 2025-05-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -426,6 +426,9 @@ When calling `zoxide init`, the following flags are available:
 Environment variables[^2] can be used for configuration. They must be set before
 `zoxide init` is called.
 
+- `_ZO_CASE_SENSITIVITY`
+  - Defaults to case-insensitive searches. Set to `case-sensitive` for
+    case-sensitive searching.
 - `_ZO_DATA_DIR`
   - Specifies the directory in which the database is stored.
   - The default value varies across OSes:

--- a/src/cmd/cmd.rs
+++ b/src/cmd/cmd.rs
@@ -22,6 +22,7 @@ https://github.com/ajeetdsouza/zoxide
 {all-args}{after-help}
 
 <bold><underline>Environment variables:</underline></bold>
+{tab}<bold>_ZO_CASE_SENSITIVITY</bold>{tab}Set case-sensitivity: case-sensitive or case-insensitive (default)
 {tab}<bold>_ZO_DATA_DIR</bold>        {tab}Path for zoxide data files
 {tab}<bold>_ZO_ECHO</bold>            {tab}Print the matched directory before navigating to it when set to 1
 {tab}<bold>_ZO_EXCLUDE_DIRS</bold>    {tab}List of directory globs to be excluded

--- a/src/cmd/query.rs
+++ b/src/cmd/query.rs
@@ -79,6 +79,7 @@ impl Query {
     fn get_stream<'a>(&self, db: &'a mut Database, now: Epoch) -> Result<Stream<'a>> {
         let mut options = StreamOptions::new(now)
             .with_keywords(self.keywords.iter().map(|s| s.as_str()))
+            .with_case_sensitivity(config::case_sensitivity())
             .with_exclude(config::exclude_dirs()?);
         if !self.all {
             let resolve_symlinks = config::resolve_symlinks();

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,33 @@ use anyhow::{Context, Result, ensure};
 use glob::Pattern;
 
 use crate::db::Rank;
+use crate::util;
+
+pub enum CaseSensitivity {
+    CaseInsensitive,
+    CaseSensitive,
+}
+
+impl CaseSensitivity {
+    pub fn convert_case(&self, s: &str) -> String {
+        match self {
+            CaseSensitivity::CaseInsensitive => util::to_lowercase(s),
+            CaseSensitivity::CaseSensitive => s.into(),
+        }
+    }
+}
+
+pub fn case_sensitivity() -> CaseSensitivity {
+    env::var_os("_ZO_CASE_SENSITIVITY")
+        .map_or(CaseSensitivity::CaseInsensitive, map_case_sensitivity)
+}
+
+fn map_case_sensitivity(s: OsString) -> CaseSensitivity {
+    match s.to_str() {
+        Some("case-sensitive") => CaseSensitivity::CaseSensitive,
+        _ => CaseSensitivity::CaseInsensitive,
+    }
+}
 
 pub fn data_dir() -> Result<PathBuf> {
     let dir = match env::var_os("_ZO_DATA_DIR") {


### PR DESCRIPTION
Add _ZO_CASE_SENSITIVITY env var to control whether queries should be performed in a case-sensitive manner, keeping the current behavior (case-insensitive) as the default.

Setting _ZO_CASE_SENSITIVITY=case-sensitive changes the query behavior to be case-sensitive.

---

I switched to zoxide a few months ago and have found it to be a much more robust tool than what I was using before. I also enjoy all of the integrations it has.

One thing I miss from my previous jump tool is case-sensitivity: I have some dirs that happen to have capitalization that I can use to get to exactly where I want to go, with a single character, as long as the search is case sensitive.

This PR adds case-sensitivity as an option. This could also lay the groundwork for a "smart case" variant (requested in https://github.com/ajeetdsouza/zoxide/issues/224)

Also, I've done minimal rust, so if anything here is not idiomatic / should be adjusted happy to make any changes.
