### PR TITLE
update nushell init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,11 +407,13 @@ When calling `zoxide init`, the following flags are available:
   - `--cmd cd` would replace the `cd` command.
 - `--hook <HOOK>`
   - Changes how often zoxide increments a directory's score:
+
     | Hook            | Description                       |
     | --------------- | --------------------------------- |
     | `none`          | Never                             |
     | `prompt`        | At every shell prompt             |
     | `pwd` (default) | Whenever the directory is changed |
+
 - `--no-cmd`
   - Prevents zoxide from defining the `z` and `zi` commands.
   - These functions will still be available in your shell as `__zoxide_z` and
@@ -425,11 +427,13 @@ Environment variables[^2] can be used for configuration. They must be set before
 - `_ZO_DATA_DIR`
   - Specifies the directory in which the database is stored.
   - The default value varies across OSes:
+
     | OS          | Path                                     | Example                                    |
     | ----------- | ---------------------------------------- | ------------------------------------------ |
     | Linux / BSD | `$XDG_DATA_HOME` or `$HOME/.local/share` | `/home/alice/.local/share`                 |
     | macOS       | `$HOME/Library/Application Support`      | `/Users/Alice/Library/Application Support` |
     | Windows     | `%LOCALAPPDATA%`                         | `C:\Users\Alice\AppData\Local`             |
+
 - `_ZO_ECHO`
   - When set to 1, `z` will print the matched directory before navigating to
     it.
@@ -437,10 +441,12 @@ Environment variables[^2] can be used for configuration. They must be set before
   - Excludes the specified directories from the database.
   - This is provided as a list of [globs][glob], separated by OS-specific
     characters:
+
     | OS                  | Separator | Example                 |
     | ------------------- | --------- | ----------------------- |
     | Linux / macOS / BSD | `:`       | `$HOME:$HOME/private/*` |
     | Windows             | `;`       | `$HOME;$HOME/private/*` |
+
   - By default, this is set to `"$HOME"`.
 - `_ZO_FZF_OPTS`
   - Custom options to pass to [fzf] during interactive selection. See

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -5,4 +5,4 @@ use_field_init_shorthand = true
 use_small_heuristics = "Max"
 use_try_shorthand = true
 wrap_comments = true
-version = "Two"
+style_edition = "2024"

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 let
   pkgs = import (builtins.fetchTarball
-    "https://github.com/NixOS/nixpkgs/archive/4d513ab5f170d66afa3387bdd718d41aa936ee9f.tar.gz") {
+    "https://github.com/NixOS/nixpkgs/archive/056faf24027e12f0ba6edebe299ed136e030d29a.tar.gz") {
       overlays = [ rust ];
     };
   rust = import (builtins.fetchTarball

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,7 @@ let
       overlays = [ rust ];
     };
   rust = import (builtins.fetchTarball
-    "https://github.com/oxalica/rust-overlay/archive/ab150c7412db7bea5879ce2776718f53fba37aa2.tar.gz");
+    "https://github.com/oxalica/rust-overlay/archive/f61820fa2c3844d6940cce269a6afdec30aa2e6c.tar.gz");
 
   rust-nightly =
     pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.minimal);

--- a/src/cmd/add.rs
+++ b/src/cmd/add.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 
 use crate::cmd::{Add, Run};
 use crate::db::Database;

--- a/src/cmd/import.rs
+++ b/src/cmd/import.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 
 use crate::cmd::{Import, ImportFrom, Run};
 use crate::db::Database;

--- a/src/cmd/remove.rs
+++ b/src/cmd/remove.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 
 use crate::cmd::{Remove, Run};
 use crate::db::Database;

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::ffi::OsString;
 use std::path::PathBuf;
 
-use anyhow::{ensure, Context, Result};
+use anyhow::{Context, Result, ensure};
 use glob::Pattern;
 
 use crate::db::Rank;
@@ -20,7 +20,7 @@ pub fn data_dir() -> Result<PathBuf> {
 }
 
 pub fn echo() -> bool {
-    env::var_os("_ZO_ECHO").map_or(false, |var| var == "1")
+    env::var_os("_ZO_ECHO").is_some_and(|var| var == "1")
 }
 
 pub fn exclude_dirs() -> Result<Vec<Pattern>> {
@@ -58,5 +58,5 @@ pub fn maxage() -> Result<Rank> {
 }
 
 pub fn resolve_symlinks() -> bool {
-    env::var_os("_ZO_RESOLVE_SYMLINKS").map_or(false, |var| var == "1")
+    env::var_os("_ZO_RESOLVE_SYMLINKS").is_some_and(|var| var == "1")
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -4,7 +4,7 @@ mod stream;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use bincode::Options;
 use ouroboros::self_referencing;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display, Formatter};
 use std::io;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 
 /// Custom error type for early exit.
 #[derive(Debug)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,7 +8,7 @@ use std::{env, mem};
 
 #[cfg(windows)]
 use anyhow::anyhow;
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 
 use crate::db::{Dir, Epoch};
 use crate::error::SilentExit;

--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -13,44 +13,40 @@
 {%- else -%}
 # Initialize hook to add new entries to the database.
 export-env {
-  {%- if hook == InitHook::Prompt %}
-  let hooked = (
-    $env.config?.hooks?.pre_prompt?
-    | default []
-    | any { try {get zoxide} catch { false } }
+{%- if hook == InitHook::Prompt %}
+  $env.config = (
+    $env.config?
+    | default {}
+    | upsert hooks { default {} }
+    | upsert hooks.pre_prompt { default [] }
   )
-  if not $hooked {
-    $env.config = (
-      $env.config? | default {}
-      | upsert hooks { default {} }
-      | upsert hooks.pre_prompt { default [] }
-    )
-
+  let __zoxide_hooked = (
+    $env.config.hooks.pre_prompt | any { try { get __zoxide_hook } catch { false } }
+  )
+  if not $__zoxide_hooked {
     $env.config.hooks.pre_prompt = ($env.config.hooks.pre_prompt | append {
-      zoxide: true,
+      __zoxide_hook: true,
       code: {|| zoxide add -- $env.PWD}
     })
   }
-  {%- else if hook == InitHook::Pwd %}
-  let hooked = (
-    $env.config?.hooks?.env_change?.PWD?
-    | default []
-    | any { try {get zoxide} catch { false } }
+{%- else if hook == InitHook::Pwd %}
+  $env.config = (
+    $env.config?
+    | default {}
+    | upsert hooks { default {} }
+    | upsert hooks.env_change { default {} }
+    | upsert hooks.env_change.PWD { default [] }
   )
-  if not $hooked {
-    $env.config = (
-      $env.config? | default {}
-      | upsert hooks { default {} }
-      | upsert hooks.env_change { default {} }
-      | upsert hooks.env_change.PWD { default [] }
-    )
-
+  let __zoxide_hooked = (
+    $env.config.hooks.env_change.PWD | any { try { get __zoxide_hook } catch { false } }
+  )
+  if not $__zoxide_hooked {
     $env.config.hooks.env_change.PWD = ($env.config.hooks.env_change.PWD | append {
-      zoxide: true,
+      __zoxide_hook: true,
       code: {|_, dir| zoxide add -- $dir}
     })
   }
-  {%- endif %}
+{%- endif %}
 }
 
 {%- endif %}

--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -39,13 +39,14 @@ if (not ($env | default false __zoxide_hooked | get __zoxide_hooked)) {
 #
 
 # Jump to a directory using only keywords.
-def --env --wrapped __zoxide_z [...rest:string] {
-  let arg0 = ($rest | append '~').0
-  let arg0_is_dir = (try {$arg0 | path expand | path type}) == 'dir'
-  let path = if (($rest | length) <= 1) and ($arg0 == '-' or $arg0_is_dir) {
-    $arg0
-  } else {
-    (zoxide query --exclude $env.PWD -- ...$rest | str trim -r -c "\n")
+def --env --wrapped __zoxide_z [...rest: string] {
+  let path = match $rest {
+    [] => {'~'},
+    [ '-' ] => {'-'},
+    [ $arg ] if ($arg | path type) == 'dir' => {$arg}
+    _ => {
+      zoxide query --exclude $env.PWD -- ...$rest | str trim -r -c "\n"
+    }
   }
   cd $path
 {%- if echo %}

--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -12,24 +12,45 @@
 
 {%- else -%}
 # Initialize hook to add new entries to the database.
-if (not ($env | default false __zoxide_hooked | get __zoxide_hooked)) {
-  $env.__zoxide_hooked = true
-{%- if hook == InitHook::Prompt %}
-  $env.config = ($env | default {} config).config
-  $env.config = ($env.config | default {} hooks)
-  $env.config = ($env.config | update hooks ($env.config.hooks | default [] pre_prompt))
-  $env.config = ($env.config | update hooks.pre_prompt ($env.config.hooks.pre_prompt | append { ||
-    zoxide add -- $env.PWD
-  }))
-{%- else if hook == InitHook::Pwd %}
-  $env.config = ($env | default {} config).config
-  $env.config = ($env.config | default {} hooks)
-  $env.config = ($env.config | update hooks ($env.config.hooks | default {} env_change))
-  $env.config = ($env.config | update hooks.env_change ($env.config.hooks.env_change | default [] PWD))
-  $env.config = ($env.config | update hooks.env_change.PWD ($env.config.hooks.env_change.PWD | append {|_, dir|
-    zoxide add -- $dir
-  }))
-{%- endif %}
+export-env {
+  {%- if hook == InitHook::Prompt %}
+  let hooked = (
+    $env.config?.hooks?.pre_prompt?
+    | default []
+    | any { try {get zoxide} catch { false } }
+  )
+  if not $hooked {
+    $env.config = (
+      $env.config? | default {}
+      | upsert hooks { default {} }
+      | upsert hooks.pre_prompt { default [] }
+    )
+
+    $env.config.hooks.pre_prompt = ($env.config.hooks.pre_prompt | append {
+      zoxide: true,
+      code: {|| zoxide add -- $env.PWD}
+    })
+  }
+  {%- else if hook == InitHook::Pwd %}
+  let hooked = (
+    $env.config?.hooks?.env_change?.PWD?
+    | default []
+    | any { try {get zoxide} catch { false } }
+  )
+  if not $hooked {
+    $env.config = (
+      $env.config? | default {}
+      | upsert hooks { default {} }
+      | upsert hooks.env_change { default {} }
+      | upsert hooks.env_change.PWD { default [] }
+    )
+
+    $env.config.hooks.env_change.PWD = ($env.config.hooks.env_change.PWD | append {
+      zoxide: true,
+      code: {|_, dir| zoxide add -- $dir}
+    })
+  }
+  {%- endif %}
 }
 
 {%- endif %}

--- a/templates/xonsh.txt
+++ b/templates/xonsh.txt
@@ -43,13 +43,13 @@ def __zoxide_pwd() -> str:
     return pwd
 
 
-def __zoxide_cd(path: typing.Optional[typing.AnyStr] = None) -> None:
+def __zoxide_cd(path: str | bytes | None = None) -> None:
     """cd + custom logic based on the value of _ZO_ECHO."""
     if path is None:
         args = []
     elif isinstance(path, bytes):
         args = [path.decode("utf-8")]
-    elif isinstance(path, str):
+    else:
         args = [path]
     _, exc, _ = xonsh.dirstack.cd(args)
     if exc is not None:


### PR DESCRIPTION
1. Made `__zoxide_z` more idiomatic
2. Updated the hook initialization to avoid breakage on nushell's future 0.102.0 release

To expand on hook initialization:
After https://github.com/nushell/nushell/pull/14704#issuecomment-2568660080, starting sub shells would make zoxide's init script throw an error.

With this PR `$env.__zoxide_hooked` is no longer used. Instead, the list of hooks are checked directly to see if zoxide's hook has already been added.

I checked the new init script on both nushell version 0.89.0 and the latest nushell nightly.
Minimum supported version of nushell doesn't need to change and can be kept at 0.89.0