### PR TITLE
updated nushell zoxide.nu to support overlay use over source

### DIFF
--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -56,7 +56,7 @@ export-env {
 #
 
 # Jump to a directory using only keywords.
-def --env --wrapped __zoxide_z [...rest: string] {
+export def --env --wrapped __zoxide_z [...rest: string] {
   let path = match $rest {
     [] => {'~'},
     [ '-' ] => {'-'},
@@ -72,7 +72,7 @@ def --env --wrapped __zoxide_z [...rest: string] {
 }
 
 # Jump to a directory using interactive search.
-def --env --wrapped __zoxide_zi [...rest:string] {
+export def --env --wrapped __zoxide_zi [...rest:string] {
   cd $'(zoxide query --interactive -- ...$rest | str trim -r -c "\n")'
 {%- if echo %}
   echo $env.PWD
@@ -86,8 +86,8 @@ def --env --wrapped __zoxide_zi [...rest:string] {
 {%- match cmd %}
 {%- when Some with (cmd) %}
 
-alias {{cmd}} = __zoxide_z
-alias {{cmd}}i = __zoxide_zi
+export alias {{cmd}} = __zoxide_z
+export alias {{cmd}}i = __zoxide_zi
 
 {%- when None %}
 
@@ -103,6 +103,6 @@ alias {{cmd}}i = __zoxide_zi
 # Now, add this to the end of your config file (find it by running
 # `$nu.config-path` in Nushell):
 #
-#   source ~/.zoxide.nu
+#   overlay use ~/.zoxide.nu as zoxide
 #
 # Note: zoxide only supports Nushell v0.89.0+.


### PR DESCRIPTION
## Overview
This update changes the `zoxide.nu` template by switching from using the `source` command to `overlay use`. The new approach offers a more flexible and manageable way to load command definitions in Nushell.

## Why Switch to `overlay use`?
- **Scope:**  
  - **`source`:** Loads definitions directly into your global session, making them always active.  
  - **`overlay use`:** Loads definitions into a separate overlay (a distinct layer) that you can easily toggle on or off as needed.

- **Management:**  
  - **`source`:** Once loaded, definitions stick around for the entire session until explicitly changed.  
  - **`overlay use`:** Overlays give you more control – you can list, hide, reload, or rename them. This means you can decide exactly which sets of definitions are active at any time.

- **Use Cases:**  
  - **`source`:** Great for quickly running a script and having everything immediately available.  
  - **`overlay use`:** Perfect for a modular setup where you want the ability to add or remove groups of commands without cluttering your global environment.

## Conclusion
By moving to `overlay use`, this update makes your Nushell experience cleaner and more organized. It offers a more modular and reversible way to manage your environment, giving you fine-grained control over your commands and settings.

Feel free to review the changes and let me know if you have any feedback. Thanks!