### PR TITLE
Fixes #995: Wildcard expansion for PowerShell

### DIFF
--- a/templates/powershell.txt
+++ b/templates/powershell.txt
@@ -107,7 +107,7 @@ function global:__zoxide_z {
         __zoxide_cd $args[0] $false
     }
     elseif ($args.Length -eq 1 -and (Test-Path $args[0] -PathType Container)) {
-        __zoxide_cd $args[0] $true
+        __zoxide_cd $args[0] $(Test-Path -LiteralPath $args[0])
     }
     else {
         $result = __zoxide_pwd

--- a/templates/powershell.txt
+++ b/templates/powershell.txt
@@ -106,8 +106,11 @@ function global:__zoxide_z {
     elseif ($args.Length -eq 1 -and ($args[0] -eq '-' -or $args[0] -eq '+')) {
         __zoxide_cd $args[0] $false
     }
-    elseif ($args.Length -eq 1 -and (Test-Path $args[0] -PathType Container)) {
-        __zoxide_cd $args[0] $(Test-Path -LiteralPath $args[0])
+    elseif ($args.Length -eq 1 -and (Test-Path $args[0] -PathType Container -LiteralPath)) {
+        __zoxide_cd $args[0] $true
+    }
+    elseif ($args.Length -eq 1 -and (Test-Path $args[0] -PathType Container -Path)) {
+        __zoxide_cd $args[0] $false
     }
     else {
         $result = __zoxide_pwd


### PR DESCRIPTION
Modifying the `__zoxide_z` function to support wildcard expansion in the current directory, allowing users to navigate to matching directories dynamically. This update enhances usability by resolving wildcard expressions (*, ?) before attempting to change directories, ensuring a smoother experience when working with complex directory structures