### PR TITLE
Explain that `_ZO_EXCLUDE_DIRS` doesn't remove existing entries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,8 @@ Environment variables[^2] can be used for configuration. They must be set before
     | Windows             | `;`       | `$HOME;$HOME/private/*` |
 
   - By default, this is set to `"$HOME"`.
+  - This does not exclude directories that have already been added to the database.
+    You must remove them using `zoxide edit`.
 - `_ZO_FZF_OPTS`
   - Custom options to pass to [fzf] during interactive selection. See
     [`man fzf`][fzf-man] for the list of options.


### PR DESCRIPTION
When trying to use `_ZO_EXCLUDE_DIRS`, I was confused why it wasn't working with `zi`. It turns out that it worked well, but some of the directories I wanted to exclude were already in the database.

I have added a line to the README to make this clearer.