### PR TITLE
Clearer error messages when no matches are found

### DIFF
--- a/src/cmd/query.rs
+++ b/src/cmd/query.rs
@@ -126,18 +126,14 @@ impl Query {
     /// ## WARNING
     /// Clones `self.keywords`
     fn format_keywords(&self) -> String {
-        if self.keywords.is_empty() {
-            return String::new();
+        let mut keywords = self.keywords.clone();
+        match keywords.pop() {
+            None => String::new(),
+            Some(last) => {
+                let head = keywords.join("', '");
+
+                format!("'{}', and '{}'", head, last)
+            }
         }
-
-        let result = self
-            .keywords
-            .iter()
-            .take(self.keywords.len() - 1)
-            .map(|s| s.to_string())
-            .collect::<Vec<String>>()
-            .join("', '");
-
-        format!("'{}', and '{}'", result, self.keywords.last().unwrap())
     }
 }

--- a/src/cmd/query.rs
+++ b/src/cmd/query.rs
@@ -128,7 +128,7 @@ impl Query {
     fn format_keywords(&self) -> String {
         let mut keywords = self.keywords.clone();
         match keywords.pop() {
-            None => String::new(),
+            None => "".into(),
             Some(last) => {
                 let head = keywords.join("', '");
 


### PR DESCRIPTION
## Description
Adds clearer error messages when no matches are found in a query as per #952.

An error message for the command:
`./target/debug/zoxide query foo bar baz`
Would now read:
`zoxide: no match found for 'foo', 'bar', and 'baz'`
Instead of:
`zoxide: no match found`

The intention is to differentiate the error for `zoxide: command not found` and to provide clarity.

> [!WARNING]
> This PR adds the method `format_keywords` to the `Query` struct. It is run during every query because of how expected errors are managed with context. It clones `self.keywords`; if this is undesirable, it can be refactored.