### PR TITLE
zoxide with file paths

### DIFF
--- a/src/cmd/query.rs
+++ b/src/cmd/query.rs
@@ -119,7 +119,8 @@ impl Query {
     }
 
     /// ## Returns
-    /// `self.keywords` with file paths transformed into their parent directory paths and directory paths unchanged
+    /// `self.keywords` with file paths transformed into their parent directory
+    /// paths and directory paths unchanged
     ///
     /// ## Warning
     /// Clones self.keywords

--- a/src/cmd/query.rs
+++ b/src/cmd/query.rs
@@ -125,7 +125,7 @@ impl Query {
     /// Clones self.keywords
     fn transfomed_keywords(&self) -> impl Iterator<Item = String> + use<'_> {
         self.keywords.iter().map(|keyword| {
-            if !std::path::Path::new(keyword).is_dir() {
+            if std::path::Path::new(keyword).is_file() {
                 let dirs: Vec<&str> = keyword.split("/").collect();
                 dirs.split_last().unwrap().1.join("/").to_string()
             } else {

--- a/src/db/stream.rs
+++ b/src/db/stream.rs
@@ -48,16 +48,16 @@ impl<'a> Stream<'a> {
     }
 
     fn filter_by_keywords(&self, path: &str) -> bool {
-        let (keywords_last, keywords) = match self.options.keywords.split_last() {
+        let (last_keyword, keywords) = match self.options.keywords.split_last() {
             Some(split) => split,
             None => return true,
         };
 
         let path = util::to_lowercase(path);
         let mut path = path.as_str();
-        match path.rfind(keywords_last) {
+        match path.rfind(last_keyword) {
             Some(idx) => {
-                if path[idx + keywords_last.len()..].contains(path::is_separator) {
+                if path[idx + last_keyword.len()..].contains(path::is_separator) {
                     return false;
                 }
                 path = &path[..idx];


### PR DESCRIPTION
## Description
Allows users to use file paths to change their current directory to that file's parent directory as per #1015.

The intended behavior of `z foo/bar.baz` would be to change their cwd into the directory matching `foo/`.

This PR accomplishes this by mapping over `self.keywords` in `Query::get_stream`.

> [!WARNING]
> Introduces the method `transformed_keywords` on `Query` which is called every time a query command is run, and a several heap allocation for each keyword.
> More importantly, it does not modify `self.keywords`, meaning any uses of `self.keywords` along the query control flow after the stream is constructed won't match up with the stream.
> As far as I can tell though, there are no such usages.