### PR TITLE
zi automatically selects only initial result

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,8 @@ Environment variables[^2] can be used for configuration. They must be set before
     database.
 - `_ZO_ZI_ONLY_RESULT`
   - When set to 1, `zi foo` will automatically select the only result `fzf` returns.
-  - However, if only one result is available during selection in the `fzf` menu, it will not be automatically selected.
+  - However, if only one result is available during selection in the `fzf` menu,
+    it will not be automatically selected.
 
 ## Third-party integrations
 

--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ When calling `zoxide init`, the following flags are available:
   - `--cmd j` would change the commands to (`j`, `ji`).
   - `--cmd cd` would replace the `cd` command.
 - `--hook <HOOK>`
+
   - Changes how often zoxide increments a directory's score:
 
     | Hook            | Description                       |
@@ -414,6 +415,7 @@ Environment variables[^2] can be used for configuration. They must be set before
 `zoxide init` is called.
 
 - `_ZO_DATA_DIR`
+
   - Specifies the directory in which the database is stored.
   - The default value varies across OSes:
 
@@ -427,6 +429,7 @@ Environment variables[^2] can be used for configuration. They must be set before
   - When set to 1, `z` will print the matched directory before navigating to
     it.
 - `_ZO_EXCLUDE_DIRS`
+
   - Excludes the specified directories from the database.
   - This is provided as a list of [globs][glob], separated by OS-specific
     characters:
@@ -437,6 +440,7 @@ Environment variables[^2] can be used for configuration. They must be set before
     | Windows             | `;`       | `$HOME;$HOME/private/*` |
 
   - By default, this is set to `"$HOME"`.
+
 - `_ZO_FZF_OPTS`
   - Custom options to pass to [fzf] during interactive selection. See
     [`man fzf`][fzf-man] for the list of options.
@@ -447,6 +451,9 @@ Environment variables[^2] can be used for configuration. They must be set before
 - `_ZO_RESOLVE_SYMLINKS`
   - When set to 1, `z` will resolve symlinks before adding directories to the
     database.
+- `_ZO_ZI_ONLY_RESULT`
+  - When set to 1, `zi foo` will automatically select the only result `fzf` returns.
+  - However, if only one result is available during selection in the `fzf` menu, it will not be automatically selected.
 
 ## Third-party integrations
 

--- a/build.rs
+++ b/build.rs
@@ -11,6 +11,7 @@ use cmd::Cmd;
 fn main() -> io::Result<()> {
     // Since we are generating completions in the package directory, we need to
     // set this so that Cargo doesn't rebuild every time.
+    println!("cargo:rustc-check-cfg=cfg(test)");
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=src/");
     println!("cargo:rerun-if-changed=templates/");

--- a/src/cmd/cmd.rs
+++ b/src/cmd/cmd.rs
@@ -27,7 +27,8 @@ https://github.com/ajeetdsouza/zoxide
 {tab}<bold>_ZO_EXCLUDE_DIRS</bold>    {tab}List of directory globs to be excluded
 {tab}<bold>_ZO_FZF_OPTS</bold>        {tab}Custom flags to pass to fzf
 {tab}<bold>_ZO_MAXAGE</bold>          {tab}Maximum total age after which entries start getting deleted
-{tab}<bold>_ZO_RESOLVE_SYMLINKS</bold>{tab}Resolve symlinks when storing paths").into_resettable()
+{tab}<bold>_ZO_RESOLVE_SYMLINKS</bold>{tab}Resolve symlinks when storing paths
+{tab}<bold>_ZO_ZI_ONLY_RESULT</bold>{tab}Automatically select only result after fzf initialization (but not while fuzzy finding)").into_resettable()
     }
 }
 

--- a/src/cmd/query.rs
+++ b/src/cmd/query.rs
@@ -3,7 +3,7 @@ use std::io::{self, Write};
 use anyhow::{Context, Result};
 
 use crate::cmd::{Query, Run};
-use crate::config::{self};
+use crate::config;
 use crate::db::{Database, Epoch, Stream, StreamOptions};
 use crate::error::BrokenPipeHandler;
 use crate::util::{self, Fzf, FzfChild};

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,3 +60,7 @@ pub fn maxage() -> Result<Rank> {
 pub fn resolve_symlinks() -> bool {
     env::var_os("_ZO_RESOLVE_SYMLINKS").is_some_and(|var| var == "1")
 }
+
+pub fn zi_only_result() -> bool {
+    env::var_os("_ZO_ZI_ONLY_RESULT").is_some_and(|var| var == "1")
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,7 +8,7 @@ use std::{env, mem};
 
 #[cfg(windows)]
 use anyhow::anyhow;
-use anyhow::{Context, Error, Result, bail};
+use anyhow::{Context, Result, bail};
 
 use crate::db::{Dir, Epoch};
 use crate::error::SilentExit;

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,7 +8,7 @@ use std::{env, mem};
 
 #[cfg(windows)]
 use anyhow::anyhow;
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Error, Result, bail};
 
 use crate::db::{Dir, Epoch};
 use crate::error::SilentExit;
@@ -147,6 +147,10 @@ impl FzfChild {
             Some(128..=254) | None => bail!("fzf was terminated"),
             _ => bail!("fzf returned an unknown error"),
         }
+    }
+
+    pub fn close(&mut self) -> Result<()> {
+        self.0.kill().map_err(|err| err.into())
     }
 }
 


### PR DESCRIPTION
## Description
`zi foo` will now automatically select the only initial result if applicable, as per #997.

## Usage
The command `zoxide query --interactive foo` will now automatically select the only result initially returned, if there is only one. If there is initially more than one result, but further fuzzy-finding narrows it down to just one, that final result will not be automatically selected.

## Environment Variable
A new environment variable `_ZO_ZI_ONLY_RESULT` has been introduced which toggles the behavior described above with the current behavior of `zi`.