### PR TITLE
Pwsh zoxide add to database when used along with starship

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "zoxide"
 readme = "README.md"
 repository = "https://github.com/ajeetdsouza/zoxide"
 rust-version = "1.74.1"
-version = "0.9.8"
+version = "0.9.7"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "zoxide"
 readme = "README.md"
 repository = "https://github.com/ajeetdsouza/zoxide"
 rust-version = "1.74.1"
-version = "0.9.7"
+version = "0.9.8"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/templates/powershell.txt
+++ b/templates/powershell.txt
@@ -86,10 +86,13 @@ if ($global:__zoxide_hooked -ne 1) {
     $global:__zoxide_prompt_old = $function:prompt
 
     function global:prompt {
-        if ($null -ne $__zoxide_prompt_old) {
-            & $__zoxide_prompt_old
+        $customPrompt = ""
+        if ($null -ne $global:__zoxide_prompt_old) {
+            $customPrompt = & $global:__zoxide_prompt_old
         }
         $null = __zoxide_hook
+
+        return $customPrompt
     }
 }
 {%- endif %}


### PR DESCRIPTION
Zoxide wasn't adding directories when using newer versions of powershell (pwsh) when used alongside starship. This fix ensures that Zoxide still updates its database without interfering with Starship.  