### PR TITLE
--basedir query option

### DIFF
--- a/contrib/completions/_zoxide
+++ b/contrib/completions/_zoxide
@@ -120,7 +120,7 @@ _arguments "${_arguments_options[@]}" : \
 (query)
 _arguments "${_arguments_options[@]}" : \
 '--exclude=[Exclude the current directory]:path:_files -/' \
-'(--exclude)--basedir=[Only search within this directory]:path:_files -/' \
+'--base-dir=[Only search within this directory]:path:_files -/' \
 '-a[Show unavailable directories]' \
 '--all[Show unavailable directories]' \
 '(-l --list)-i[Use interactive selection]' \

--- a/contrib/completions/_zoxide
+++ b/contrib/completions/_zoxide
@@ -120,6 +120,7 @@ _arguments "${_arguments_options[@]}" : \
 (query)
 _arguments "${_arguments_options[@]}" : \
 '--exclude=[Exclude the current directory]:path:_files -/' \
+'(--exclude)--basedir=[Only search within this directory]:path:_files -/' \
 '-a[Show unavailable directories]' \
 '--all[Show unavailable directories]' \
 '(-l --list)-i[Use interactive selection]' \

--- a/contrib/completions/_zoxide.ps1
+++ b/contrib/completions/_zoxide.ps1
@@ -102,7 +102,7 @@ Register-ArgumentCompleter -Native -CommandName 'zoxide' -ScriptBlock {
         }
         'zoxide;query' {
             [CompletionResult]::new('--exclude', '--exclude', [CompletionResultType]::ParameterName, 'Exclude the current directory')
-            [CompletionResult]::new('--basedir', '--basedir', [CompletionResultType]::ParameterName, 'Only search within this directory')
+            [CompletionResult]::new('--base-dir', '--base-dir', [CompletionResultType]::ParameterName, 'Only search within this directory')
             [CompletionResult]::new('-a', '-a', [CompletionResultType]::ParameterName, 'Show unavailable directories')
             [CompletionResult]::new('--all', '--all', [CompletionResultType]::ParameterName, 'Show unavailable directories')
             [CompletionResult]::new('-i', '-i', [CompletionResultType]::ParameterName, 'Use interactive selection')

--- a/contrib/completions/_zoxide.ps1
+++ b/contrib/completions/_zoxide.ps1
@@ -102,6 +102,7 @@ Register-ArgumentCompleter -Native -CommandName 'zoxide' -ScriptBlock {
         }
         'zoxide;query' {
             [CompletionResult]::new('--exclude', '--exclude', [CompletionResultType]::ParameterName, 'Exclude the current directory')
+            [CompletionResult]::new('--basedir', '--basedir', [CompletionResultType]::ParameterName, 'Only search within this directory')
             [CompletionResult]::new('-a', '-a', [CompletionResultType]::ParameterName, 'Show unavailable directories')
             [CompletionResult]::new('--all', '--all', [CompletionResultType]::ParameterName, 'Show unavailable directories')
             [CompletionResult]::new('-i', '-i', [CompletionResultType]::ParameterName, 'Use interactive selection')

--- a/contrib/completions/zoxide.bash
+++ b/contrib/completions/zoxide.bash
@@ -199,7 +199,7 @@ _zoxide() {
             return 0
             ;;
         zoxide__query)
-            opts="-a -i -l -s -h -V --all --interactive --list --score --exclude --basedir --help --version [KEYWORDS]..."
+            opts="-a -i -l -s -h -V --all --interactive --list --score --exclude --base-dir --help --version [KEYWORDS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -212,7 +212,7 @@ _zoxide() {
                     fi
                     return 0
                     ;;
-                --basedir)
+                --base-dir)
                     COMPREPLY=()
                     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
                         compopt -o plusdirs

--- a/contrib/completions/zoxide.bash
+++ b/contrib/completions/zoxide.bash
@@ -199,13 +199,20 @@ _zoxide() {
             return 0
             ;;
         zoxide__query)
-            opts="-a -i -l -s -h -V --all --interactive --list --score --exclude --help --version [KEYWORDS]..."
+            opts="-a -i -l -s -h -V --all --interactive --list --score --exclude --basedir --help --version [KEYWORDS]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 --exclude)
+                    COMPREPLY=()
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o plusdirs
+                    fi
+                    return 0
+                    ;;
+                --basedir)
                     COMPREPLY=()
                     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
                         compopt -o plusdirs

--- a/contrib/completions/zoxide.elv
+++ b/contrib/completions/zoxide.elv
@@ -90,6 +90,7 @@ set edit:completion:arg-completer[zoxide] = {|@words|
         }
         &'zoxide;query'= {
             cand --exclude 'Exclude the current directory'
+            cand --basedir 'Only search within this directory'
             cand -a 'Show unavailable directories'
             cand --all 'Show unavailable directories'
             cand -i 'Use interactive selection'

--- a/contrib/completions/zoxide.elv
+++ b/contrib/completions/zoxide.elv
@@ -90,7 +90,7 @@ set edit:completion:arg-completer[zoxide] = {|@words|
         }
         &'zoxide;query'= {
             cand --exclude 'Exclude the current directory'
-            cand --basedir 'Only search within this directory'
+            cand --base-dir 'Only search within this directory'
             cand -a 'Show unavailable directories'
             cand --all 'Show unavailable directories'
             cand -i 'Use interactive selection'

--- a/contrib/completions/zoxide.fish
+++ b/contrib/completions/zoxide.fish
@@ -62,7 +62,7 @@ complete -c zoxide -n "__fish_zoxide_using_subcommand init" -l no-cmd -d 'Preven
 complete -c zoxide -n "__fish_zoxide_using_subcommand init" -s h -l help -d 'Print help'
 complete -c zoxide -n "__fish_zoxide_using_subcommand init" -s V -l version -d 'Print version'
 complete -c zoxide -n "__fish_zoxide_using_subcommand query" -l exclude -d 'Exclude the current directory' -r -f -a "(__fish_complete_directories)"
-complete -c zoxide -n "__fish_zoxide_using_subcommand query" -l basedir -d 'Only search within this directory' -r -f -a "(__fish_complete_directories)"
+complete -c zoxide -n "__fish_zoxide_using_subcommand query" -l base-dir -d 'Only search within this directory' -r -f -a "(__fish_complete_directories)"
 complete -c zoxide -n "__fish_zoxide_using_subcommand query" -s a -l all -d 'Show unavailable directories'
 complete -c zoxide -n "__fish_zoxide_using_subcommand query" -s i -l interactive -d 'Use interactive selection'
 complete -c zoxide -n "__fish_zoxide_using_subcommand query" -s l -l list -d 'List all matching directories'

--- a/contrib/completions/zoxide.fish
+++ b/contrib/completions/zoxide.fish
@@ -62,6 +62,7 @@ complete -c zoxide -n "__fish_zoxide_using_subcommand init" -l no-cmd -d 'Preven
 complete -c zoxide -n "__fish_zoxide_using_subcommand init" -s h -l help -d 'Print help'
 complete -c zoxide -n "__fish_zoxide_using_subcommand init" -s V -l version -d 'Print version'
 complete -c zoxide -n "__fish_zoxide_using_subcommand query" -l exclude -d 'Exclude the current directory' -r -f -a "(__fish_complete_directories)"
+complete -c zoxide -n "__fish_zoxide_using_subcommand query" -l basedir -d 'Only search within this directory' -r -f -a "(__fish_complete_directories)"
 complete -c zoxide -n "__fish_zoxide_using_subcommand query" -s a -l all -d 'Show unavailable directories'
 complete -c zoxide -n "__fish_zoxide_using_subcommand query" -s i -l interactive -d 'Use interactive selection'
 complete -c zoxide -n "__fish_zoxide_using_subcommand query" -s l -l list -d 'List all matching directories'

--- a/contrib/completions/zoxide.nu
+++ b/contrib/completions/zoxide.nu
@@ -82,6 +82,7 @@ module completions {
     --list(-l)                # List all matching directories
     --score(-s)               # Print score with results
     --exclude: path           # Exclude the current directory
+    --basedir: path           # Only search within this directory
     --help(-h)                # Print help
     --version(-V)             # Print version
   ]

--- a/contrib/completions/zoxide.nu
+++ b/contrib/completions/zoxide.nu
@@ -82,7 +82,7 @@ module completions {
     --list(-l)                # List all matching directories
     --score(-s)               # Print score with results
     --exclude: path           # Exclude the current directory
-    --basedir: path           # Only search within this directory
+    --base-dir: path          # Only search within this directory
     --help(-h)                # Print help
     --version(-V)             # Print version
   ]

--- a/contrib/completions/zoxide.ts
+++ b/contrib/completions/zoxide.ts
@@ -215,14 +215,11 @@ const completion: Fig.Spec = {
           },
         },
         {
-          name: "--basedir",
+          name: "--base-dir",
           description: "Only search within this directory",
-          exclusiveOn: [
-            "--exclude",
-          ],
           isRepeatable: true,
           args: {
-            name: "basedir",
+            name: "base_dir",
             isOptional: true,
             template: "folders",
           },

--- a/contrib/completions/zoxide.ts
+++ b/contrib/completions/zoxide.ts
@@ -215,6 +215,19 @@ const completion: Fig.Spec = {
           },
         },
         {
+          name: "--basedir",
+          description: "Only search within this directory",
+          exclusiveOn: [
+            "--exclude",
+          ],
+          isRepeatable: true,
+          args: {
+            name: "basedir",
+            isOptional: true,
+            template: "folders",
+          },
+        },
+        {
           name: ["-a", "--all"],
           description: "Show unavailable directories",
         },

--- a/src/cmd/cmd.rs
+++ b/src/cmd/cmd.rs
@@ -186,6 +186,10 @@ pub struct Query {
     /// Exclude the current directory
     #[clap(long, value_hint = ValueHint::DirPath, value_name = "path")]
     pub exclude: Option<String>,
+
+    /// Only search within this directory
+    #[clap(long, value_hint = ValueHint::DirPath, value_name = "path", conflicts_with = "exclude")]
+    pub basedir: Option<String>,
 }
 
 /// Remove a directory from the database

--- a/src/cmd/cmd.rs
+++ b/src/cmd/cmd.rs
@@ -188,8 +188,8 @@ pub struct Query {
     pub exclude: Option<String>,
 
     /// Only search within this directory
-    #[clap(long, value_hint = ValueHint::DirPath, value_name = "path", conflicts_with = "exclude")]
-    pub basedir: Option<String>,
+    #[clap(long, value_hint = ValueHint::DirPath, value_name = "path")]
+    pub base_dir: Option<String>,
 }
 
 /// Remove a directory from the database

--- a/src/cmd/query.rs
+++ b/src/cmd/query.rs
@@ -79,7 +79,8 @@ impl Query {
     fn get_stream<'a>(&self, db: &'a mut Database, now: Epoch) -> Result<Stream<'a>> {
         let mut options = StreamOptions::new(now)
             .with_keywords(self.keywords.iter().map(|s| s.as_str()))
-            .with_exclude(config::exclude_dirs()?);
+            .with_exclude(config::exclude_dirs()?)
+            .with_basedir(self.basedir.clone());
         if !self.all {
             let resolve_symlinks = config::resolve_symlinks();
             options = options.with_exists(true).with_resolve_symlinks(resolve_symlinks);

--- a/src/cmd/query.rs
+++ b/src/cmd/query.rs
@@ -80,7 +80,7 @@ impl Query {
         let mut options = StreamOptions::new(now)
             .with_keywords(self.keywords.iter().map(|s| s.as_str()))
             .with_exclude(config::exclude_dirs()?)
-            .with_basedir(self.basedir.clone());
+            .with_base_dir(self.base_dir.clone());
         if !self.all {
             let resolve_symlinks = config::resolve_symlinks();
             options = options.with_exists(true).with_resolve_symlinks(resolve_symlinks);

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -183,7 +183,7 @@ impl Database {
         *self.borrow_dirty()
     }
 
-    pub fn dirs(&self) -> &[Dir] {
+    pub fn dirs(&self) -> &[Dir<'_>] {
         self.borrow_dirs()
     }
 
@@ -203,7 +203,7 @@ impl Database {
         .context("could not serialize database")
     }
 
-    fn deserialize(bytes: &[u8]) -> Result<Vec<Dir>> {
+    fn deserialize(bytes: &[u8]) -> Result<Vec<Dir<'_>>> {
         // Assume a maximum size for the database. This prevents bincode from throwing
         // strange errors when it encounters invalid data.
         const MAX_SIZE: u64 = 32 << 20; // 32 MiB

--- a/src/db/stream.rs
+++ b/src/db/stream.rs
@@ -204,7 +204,7 @@ mod tests {
     #[case(&["/foo/", "/bar"], "/foo/bar", false)]
     #[case(&["/foo/", "/bar"], "/foo/baz/bar", true)]
     fn query(#[case] keywords: &[&str], #[case] path: &str, #[case] is_match: bool) {
-        let db = &mut Database::new(PathBuf::new(), Vec::new(), |_| Vec::new(), false);
+        let db = &mut Database::new(PathBuf::default(), Vec::default(), |_| Vec::default(), false);
         let options = StreamOptions::new(0).with_keywords(keywords.iter());
         let stream = Stream::new(db, options);
         assert_eq!(is_match, stream.filter_by_keywords(path));

--- a/src/db/stream.rs
+++ b/src/db/stream.rs
@@ -54,7 +54,7 @@ impl<'a> Stream<'a> {
     }
 
     fn filter_by_base_dir(&self, path: &str) -> bool {
-        match path {
+        match &self.options.base_dir {
             Some(base_dir) => Path::new(path).starts_with(base_dir),
             None => true,
         }

--- a/src/db/stream.rs
+++ b/src/db/stream.rs
@@ -1,6 +1,6 @@
 use std::iter::Rev;
 use std::ops::Range;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::{fs, path};
 
 use glob::Pattern;

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -97,7 +97,7 @@ mod tests {
     #[apply(opts)]
     fn elvish_elvish(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
         let opts = Opts { cmd, hook, echo, resolve_symlinks };
-        let mut source = String::default();
+        let mut source = String::new();
 
         // Filter out lines using edit:*, since those functions are only available in
         // the interactive editor.

--- a/src/util.rs
+++ b/src/util.rs
@@ -135,7 +135,7 @@ impl FzfChild {
         mem::drop(self.0.stdin.take());
 
         let mut stdout = self.0.stdout.take().unwrap();
-        let mut output = String::default();
+        let mut output = String::new();
         stdout.read_to_string(&mut output).context("failed to read from fzf")?;
 
         let status = self.0.wait().context("wait failed on fzf")?;


### PR DESCRIPTION
## Description
Adds the `--basedir foo` flag to `zoxide query` as per #944. It restricts results to the given directory and is thus incompatible with `--exclude bar` as they could be passed the same argument.