### PR TITLE
Add `--score` option

### DIFF
--- a/contrib/completions/_zoxide
+++ b/contrib/completions/_zoxide
@@ -30,6 +30,8 @@ _zoxide() {
         case $line[1] in
             (add)
 _arguments "${_arguments_options[@]}" : \
+'-s+[The rank to increment the entry if it exists or initialize it with if it doesn'\''t]:SCORE: ' \
+'--score=[The rank to increment the entry if it exists or initialize it with if it doesn'\''t]:SCORE: ' \
 '-h[Print help]' \
 '--help[Print help]' \
 '-V[Print version]' \

--- a/contrib/completions/_zoxide.ps1
+++ b/contrib/completions/_zoxide.ps1
@@ -34,6 +34,8 @@ Register-ArgumentCompleter -Native -CommandName 'zoxide' -ScriptBlock {
             break
         }
         'zoxide;add' {
+            [CompletionResult]::new('-s', '-s', [CompletionResultType]::ParameterName, 'The rank to increment the entry if it exists or initialize it with if it doesn''t')
+            [CompletionResult]::new('--score', '--score', [CompletionResultType]::ParameterName, 'The rank to increment the entry if it exists or initialize it with if it doesn''t')
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
             [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
             [CompletionResult]::new('-V', '-V ', [CompletionResultType]::ParameterName, 'Print version')

--- a/contrib/completions/zoxide.bash
+++ b/contrib/completions/zoxide.bash
@@ -63,12 +63,20 @@ _zoxide() {
             return 0
             ;;
         zoxide__add)
-            opts="-h -V --help --version <PATHS>..."
+            opts="-s -h -V --score --help --version <PATHS>..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --score)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;

--- a/contrib/completions/zoxide.elv
+++ b/contrib/completions/zoxide.elv
@@ -30,6 +30,8 @@ set edit:completion:arg-completer[zoxide] = {|@words|
             cand remove 'Remove a directory from the database'
         }
         &'zoxide;add'= {
+            cand -s 'The rank to increment the entry if it exists or initialize it with if it doesn''t'
+            cand --score 'The rank to increment the entry if it exists or initialize it with if it doesn''t'
             cand -h 'Print help'
             cand --help 'Print help'
             cand -V 'Print version'

--- a/contrib/completions/zoxide.fish
+++ b/contrib/completions/zoxide.fish
@@ -32,6 +32,7 @@ complete -c zoxide -n "__fish_zoxide_needs_command" -f -a "import" -d 'Import en
 complete -c zoxide -n "__fish_zoxide_needs_command" -f -a "init" -d 'Generate shell configuration'
 complete -c zoxide -n "__fish_zoxide_needs_command" -f -a "query" -d 'Search for a directory in the database'
 complete -c zoxide -n "__fish_zoxide_needs_command" -f -a "remove" -d 'Remove a directory from the database'
+complete -c zoxide -n "__fish_zoxide_using_subcommand add" -s s -l score -d 'The rank to increment the entry if it exists or initialize it with if it doesn\'t' -r
 complete -c zoxide -n "__fish_zoxide_using_subcommand add" -s h -l help -d 'Print help'
 complete -c zoxide -n "__fish_zoxide_using_subcommand add" -s V -l version -d 'Print version'
 complete -c zoxide -n "__fish_zoxide_using_subcommand edit; and not __fish_seen_subcommand_from decrement delete increment reload" -s h -l help -d 'Print help'

--- a/contrib/completions/zoxide.ts
+++ b/contrib/completions/zoxide.ts
@@ -7,6 +7,15 @@ const completion: Fig.Spec = {
       description: "Add a new directory or increment its rank",
       options: [
         {
+          name: ["-s", "--score"],
+          description: "The rank to increment the entry if it exists or initialize it with if it doesn't",
+          isRepeatable: true,
+          args: {
+            name: "score",
+            isOptional: true,
+          },
+        },
+        {
           name: ["-h", "--help"],
           description: "Print help",
         },

--- a/src/cmd/add.rs
+++ b/src/cmd/add.rs
@@ -33,7 +33,9 @@ impl Run for Add {
             if !Path::new(path).is_dir() {
                 bail!("not a directory: {path}");
             }
-            db.add_update(path, 1.0, now);
+
+            let by = self.score.unwrap_or(1.0);
+            db.add_update(path, by, now);
         }
 
         if db.dirty() {

--- a/src/cmd/cmd.rs
+++ b/src/cmd/cmd.rs
@@ -58,6 +58,10 @@ pub enum Cmd {
 pub struct Add {
     #[clap(num_args = 1.., required = true, value_hint = ValueHint::DirPath)]
     pub paths: Vec<PathBuf>,
+
+    /// The rank to increment the entry if it exists or initialize it with if it doesn't
+    #[clap(short, long)]
+    pub score: Option<f64>,
 }
 
 /// Edit the database


### PR DESCRIPTION
## Description
Adds the `--score` flag to the `zoxide add` command. It dictates the initial rank given to the new entry, or the value to increment it's existing rank by if the entry already exists.

> [!NOTE]
> While negative `score` values are allow (for decrementing rank), the minimum possible rank of an entry is still `0.0`.

Resolves #1010 when an initial score of zero is passed in such as `zoxide add --score 0.0 foo`.