### PR TITLE
docs: Update minimum supported fzf version

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ zoxide can be installed in 4 easy steps:
    interactive selection. It can be installed from [here][fzf-installation].
 
    > **Note**
-   > zoxide only supports fzf v0.33.0 and above.
+   > The minimum supported fzf version is v0.33.0 on most platforms and v0.51.0 on Windows.
 
 4. **Import your data** <sup>(optional)</sup>
 


### PR DESCRIPTION
Before v0.51.0, fzf generates redundant escaping of backslashes for Windows, which breaks `zoxide edit`.
https://github.com/junegunn/fzf/releases/tag/0.51.0

Closes #539

For detailed investigation, please refer to the comments around https://github.com/ajeetdsouza/zoxide/issues/539#issuecomment-2777706525.