### PR TITLE
Don't downcast PROMPT_COMMAND

### DIFF
--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -55,7 +55,11 @@ function __zoxide_hook() {
 
 # Initialize hook.
 if [[ ${PROMPT_COMMAND:=} != *'__zoxide_hook'* ]]; then
-    PROMPT_COMMAND="__zoxide_hook;${PROMPT_COMMAND#;}"
+    if [[ "$(declare -p PROMPT_COMMAND 2>&1)" == "declare -a"* ]]; then
+        PROMPT_COMMAND=(__zoxide_hook "${PROMPT_COMMAND[@]}")
+    else
+        PROMPT_COMMAND="__zoxide_hook;${PROMPT_COMMAND#;}"
+    fi
 fi
 
 {%- endif %}


### PR DESCRIPTION
Since bash 5.0 PROMPT_COMMAND is an array. Lets not turn it into a string. Copied from https://github.com/direnv/direnv/blob/master/internal/cmd/shell_bash.go#L19-L23