### PR TITLE
powershell: Ignore errors from `__zoxide_hooked`

### DIFF
--- a/templates/powershell.txt
+++ b/templates/powershell.txt
@@ -80,7 +80,7 @@ function global:__zoxide_hook {
 {%- endif %}
 
 # Initialize hook.
-$global:__zoxide_hooked = (Get-Variable __zoxide_hooked -ErrorAction SilentlyContinue -ValueOnly)
+$global:__zoxide_hooked = (Get-Variable __zoxide_hooked -ErrorAction Ignore -ValueOnly)
 if ($global:__zoxide_hooked -ne 1) {
     $global:__zoxide_hooked = 1
     $global:__zoxide_prompt_old = $function:prompt


### PR DESCRIPTION
This line currently logs to `$error` every time for no reason, it'll still work in strict mode this way.