### PR TITLE
Update zoxide to support Fish 4.1.x

### DIFF
--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -19,7 +19,11 @@ end
 # A copy of fish's internal cd function. This makes it possible to use
 # `alias cd=z` without causing an infinite loop.
 if ! builtin functions --query __zoxide_cd_internal
-    string replace --regex -- '^function cd\s' 'function __zoxide_cd_internal ' <$__fish_data_dir/functions/cd.fish | source
+    if status list-files functions/cd.fish >/dev/null
+        source (string replace --regex -- '^function cd\s' 'function __zoxide_cd_internal ' (status get-file functions/cd.fish) | psub -f)
+    else
+        source (string replace --regex -- '^function cd\s' 'function __zoxide_cd_internal ' (cat $__fish_data_dir/functions/cd.fish) | psub -f)
+    end
 end
 
 # cd + custom logic based on the value of _ZO_ECHO.


### PR DESCRIPTION
This commit updates the fish init script to support the upcoming 4.1.x release of Fish by using `status get-file`.

Fixes #1045