### PR TITLE
Add PowerShell ArgumentCompleter

### DIFF
--- a/templates/powershell.txt
+++ b/templates/powershell.txt
@@ -144,6 +144,52 @@ function global:__zoxide_zi {
 Set-Alias -Name {{cmd}} -Value __zoxide_z -Option AllScope -Scope Global -Force
 Set-Alias -Name {{cmd}}i -Value __zoxide_zi -Option AllScope -Scope Global -Force
 
+filter __zoxide_escapeStringWithSpecialChars {
+    $_ -replace '\s|#|@|\$|;|,|''|\{|\}|\(|\)|"|`|\||<|>|&','`$&'
+}
+
+Register-ArgumentCompleter -Native -CommandName "{{cmd}}" -ScriptBlock {
+    param(
+        $WordToComplete,
+        $CommandAst,
+        $CursorPosition
+    )
+
+    # Get the current command line and convert into a string
+    $Command = $CommandAst.CommandElements
+    $Command = "$Command"
+
+    # The user could have moved the cursor backwards on the command-line.
+    # We only show completions when the cursor is at the end of the line
+    if ($Command.Length -gt $CursorPosition) {
+        return
+    }
+
+    $Program,$Arguments = $Command.Split(" ",2)
+
+    # If we don't have any parameter, just use the default completion (Which is Set-Location)
+    if([string]::IsNullOrEmpty($Arguments)) {
+        return
+    }
+
+    $QueryArgs = $Arguments.Split(" ")
+
+    # If the last parameter is complete (there is a space following it)
+    if ($WordToComplete -eq "" -And ( -Not $IsEqualFlag )) {
+        # Normally, we would invoke the interactive query. Unfortunally it is not possible to invoke an
+        # interactive command in a powershell argument completer. Therefore, we just return in that case to the
+        # default completion strategy.
+        # zoxide query -i -- @QueryArgs
+        return
+    } else {
+        $result = zoxide query --exclude "$(__zoxide_pwd)" -l -- @QueryArgs
+    }
+
+    $result | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new($($_ | __zoxide_escapeStringWithSpecialChars), "$($_)", 'ParameterValue', "$($_)")
+    }
+}
+
 {%- when None %}
 
 {{ not_configured }}


### PR DESCRIPTION
Resolves #344 ,
Reopens #419

I have tried to implement an equivalent Tab completion for PowerShell, which was to some point successful. 
It works like the following:
- Use the default directory completion when no arguments are provided
- If an argument is provided, use it as zoxide query input

Unfortunately it doesn't seem to be possible to run interactive queries in PowerShell within the argument completer, therefore I don't know whether it is possible to implement the "space+tab" completion. 
Tested on Windows 11 in PowerShell just today.

This GIF shows, how it works:
![WindowsTerminal_caWG2ym896](https://user-images.githubusercontent.com/22715034/178018102-fd4ce268-7c33-4c12-a832-28912c659546.gif)

