### PR TITLE
Run the cd command after `cd ... <space><tab>` in Bash integration

### DIFF
--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -151,6 +151,8 @@ if [[ ${BASH_VERSINFO[0]:-0} -eq 4 && ${BASH_VERSINFO[1]:-0} -ge 4 || ${BASH_VER
     function __zoxide_z_complete_helper() {
         READLINE_LINE="{{ cmd }} ${__zoxide_result@Q}"
         READLINE_POINT={{ "${#READLINE_LINE}" }}
+        bind '"\e[0n": accept-line'
+        \builtin printf '\e[5n' >/dev/tty
     }
 
     function __zoxide_z_complete() {


### PR DESCRIPTION
https://github.com/ajeetdsouza/zoxide/pull/1048#issuecomment-2878390209

> > I haven't tried, but I think one can try `bind '"\e[0n": accept-line'; printf '\e[5n'` in `__zoxide_z_complete_helper`.
> 
> I did try this, but Bash will run the `accept-line` function before the line actually gets changed, so it just ends up running the command the user types in as-is.

@ajeetdsouza (cc @tessus) I now tried (as in this PR), but it seems to work. Where have you put `bind '"\e[0n": accept-line'; printf '\e[5n'`? My idea is to put it in `__zoxide_z_complete_helper` (which itself is also called through `\e[0n`).