### PR TITLE
fix: Powershell $arg[0] position in Test-Path

### DIFF
--- a/templates/powershell.txt
+++ b/templates/powershell.txt
@@ -106,10 +106,10 @@ function global:__zoxide_z {
     elseif ($args.Length -eq 1 -and ($args[0] -eq '-' -or $args[0] -eq '+')) {
         __zoxide_cd $args[0] $false
     }
-    elseif ($args.Length -eq 1 -and (Test-Path $args[0] -PathType Container -LiteralPath)) {
+    elseif ($args.Length -eq 1 -and (Test-Path -PathType Container -LiteralPath $args[0])) {
         __zoxide_cd $args[0] $true
     }
-    elseif ($args.Length -eq 1 -and (Test-Path $args[0] -PathType Container -Path)) {
+    elseif ($args.Length -eq 1 -and (Test-Path -PathType Container -Path $args[0] )) {
         __zoxide_cd $args[0] $false
     }
     else {


### PR DESCRIPTION
The changes made in commit 628f8542a01813e36edde2fba42bf0eafb9dfb05 do not take into account the requirements of [-LiteraPath](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/test-path?view=powershell-7.5#-literalpath) and [-Path](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/test-path?view=powershell-7.5#-path), since they require a String[] argument.

Thus, moving `$arg[0]` position to after both parameters fixes this issue.

![image](https://github.com/user-attachments/assets/c46e3e73-3ff7-4769-acbe-e0993a3e68ae)
