### PR TITLE
Update powershell.txt to solve uncatched hook action error in the powershell hook

### DIFF
--- a/templates/powershell.txt
+++ b/templates/powershell.txt
@@ -80,7 +80,12 @@ function global:__zoxide_hook {
 {%- endif %}
 
 # Initialize hook.
-$global:__zoxide_hooked = (Get-Variable __zoxide_hooked -ErrorAction Ignore -ValueOnly)
+try {
+    $global:__zoxide_hooked = (Get-Variable __zoxide_hooked -ValueOnly -ErrorAction Stop)
+} catch {
+    $global:__zoxide_hooked = 1
+    $Error.RemoveAt(0) # remove the lastest Get-Variable error
+}
 if ($global:__zoxide_hooked -ne 1) {
     $global:__zoxide_hooked = 1
     $global:__zoxide_prompt_old = $function:prompt


### PR DESCRIPTION
Thie change can avoid zoxide hook to influence user's handling of $Error varible. 
For example, if it is still unhandled, the zoxide init error will be propagated to user's  scope. 
Thus it will make user's script can't work as their expects.