### PR TITLE
Provide completions for Nushell

### DIFF
--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -55,29 +55,63 @@ export-env {
 # When using zoxide with --no-cmd, alias these internal functions as desired.
 #
 
-# Jump to a directory using only keywords.
-def --env --wrapped __zoxide_z [...rest: string] {
-  let path = match $rest {
-    [] => {'~'},
-    [ '-' ] => {'-'},
-    [ $arg ] if ($arg | path expand | path type) == 'dir' => {$arg}
-    _ => {
-      zoxide query --exclude $env.PWD -- ...$rest | str trim -r -c "\n"
+# For hiding the "nu-complete zoxide path" command
+module zoxide-commands {
+  def "nu-complete zoxide path" [context: string] {
+    let parts = $context | str trim | split row " " | skip 1 | each { str downcase }
+    let completions = (
+      zoxide query --list --exclude $env.PWD -- ...$parts
+        | lines
+        | each { |dir|
+          if ($parts | length) <= 1 {
+            $dir
+          } else {
+            let dir_lower = $dir | str downcase
+            let rem_start = $parts | drop 1 | reduce --fold 0 { |part, rem_start|
+              ($dir_lower | str index-of --range $rem_start.. $part) + ($part | str length)
+            }
+            {
+              value: ($dir | str substring $rem_start..),
+              description: $dir
+            }
+          }
+        })
+    {
+      options: {
+        sort: false,
+        completion_algorithm: substring,
+        case_sensitive: false,
+      },
+      completions: $completions,
     }
   }
-  cd $path
-{%- if echo %}
-  echo $env.PWD
-{%- endif %}
+
+  # Jump to a directory using only keywords.
+  export def --env --wrapped __zoxide_z [...rest: string@"nu-complete zoxide path"] {
+    let path = match $rest {
+      [] => {'~'},
+      [ '-' ] => {'-'},
+      [ $arg ] if ($arg | path expand | path type) == 'dir' => {$arg}
+      _ => {
+        zoxide query --exclude $env.PWD -- ...$rest | str trim -r -c "\n"
+      }
+    }
+    cd $path
+  {%- if echo %}
+    echo $env.PWD
+  {%- endif %}
+  }
+
+  # Jump to a directory using interactive search.
+  export def --env --wrapped __zoxide_zi [...rest:string@"nu-complete zoxide path"] {
+    cd $'(zoxide query --interactive -- ...$rest | str trim -r -c "\n")'
+  {%- if echo %}
+    echo $env.PWD
+  {%- endif %}
+  }
 }
 
-# Jump to a directory using interactive search.
-def --env --wrapped __zoxide_zi [...rest:string] {
-  cd $'(zoxide query --interactive -- ...$rest | str trim -r -c "\n")'
-{%- if echo %}
-  echo $env.PWD
-{%- endif %}
-}
+use zoxide-commands *
 
 {{ section }}
 # Commands for zoxide. Disable these using --no-cmd.


### PR DESCRIPTION
This PR provides completions for `z` and `zi`. Nushell no longer uses external completers for internal commands since v0.103 ([release notes](https://www.nushell.sh/blog/2025-03-18-nushell_0_103_0.html#external-completers-are-no-longer-used-for-internal-commands-toc)), so people's old external Zoxide completers won't work anymore.

This completer uses the option `completion_algorithm: "substring"`, which was only added in 0.104. An alternative would be to use `completion_algorithm: "prefix", positional: false`, which works in older versions but is [deprecated](https://www.nushell.sh/blog/2025-04-29-nushell_0_104_0.html#substring-match-algorithm-toc).

This completer also looks a little weird if you type in multiple arguments. If you type in `z /foo bar<TAB>`, all the completions you see will have everything up to and including the first `/foo` stripped. It's not great, but it's needed because custom completers in Nushell can't currently choose which span they want to replace. Without it, if your first result upon typing `z /foo bar<TAB>` were `/foo/bar`, hitting Enter would replace your command line with `z /foo /foo/bar`, which is incorrect.

[![asciicast](https://asciinema.org/a/cKElGuomdJVl7IF1ywrOLO7cE.svg)](https://asciinema.org/a/cKElGuomdJVl7IF1ywrOLO7cE?t=7)