### PR TITLE
adding list and clear commands along with support for importing data from txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,21 @@ zoxide can be installed in 4 easy steps:
 
    </details>
 
+   <details>
+   <summary>txt file</summary>
+
+   > In case you want to backup from txt
+   >
+   > ```sh
+   > # create a back up
+   > zoxide list > x.txt
+   > # import the backup later
+   > zoxide import --from=txt x.txt
+   > ```
+   >
+   </details>
+
+
 ## Configuration
 
 ### Flags

--- a/contrib/completions/_zoxide
+++ b/contrib/completions/_zoxide
@@ -144,6 +144,22 @@ _arguments "${_arguments_options[@]}" : \
 '*::paths:_files -/' \
 && ret=0
 ;;
+(list)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
+(clear)
+_arguments "${_arguments_options[@]}" : \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+&& ret=0
+;;
         esac
     ;;
 esac
@@ -158,6 +174,8 @@ _zoxide_commands() {
 'init:Generate shell configuration' \
 'query:Search for a directory in the database' \
 'remove:Remove a directory from the database' \
+'list:List all directory in db' \
+'clear:Remove  all directory in db' \
     )
     _describe -t commands 'zoxide commands' commands "$@"
 }
@@ -165,6 +183,11 @@ _zoxide_commands() {
 _zoxide__add_commands() {
     local commands; commands=()
     _describe -t commands 'zoxide add commands' commands "$@"
+}
+(( $+functions[_zoxide__clear_commands] )) ||
+_zoxide__clear_commands() {
+    local commands; commands=()
+    _describe -t commands 'zoxide clear commands' commands "$@"
 }
 (( $+functions[_zoxide__edit_commands] )) ||
 _zoxide__edit_commands() {
@@ -205,6 +228,11 @@ _zoxide__import_commands() {
 _zoxide__init_commands() {
     local commands; commands=()
     _describe -t commands 'zoxide init commands' commands "$@"
+}
+(( $+functions[_zoxide__list_commands] )) ||
+_zoxide__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'zoxide list commands' commands "$@"
 }
 (( $+functions[_zoxide__query_commands] )) ||
 _zoxide__query_commands() {

--- a/contrib/completions/_zoxide.ps1
+++ b/contrib/completions/_zoxide.ps1
@@ -31,6 +31,8 @@ Register-ArgumentCompleter -Native -CommandName 'zoxide' -ScriptBlock {
             [CompletionResult]::new('init', 'init', [CompletionResultType]::ParameterValue, 'Generate shell configuration')
             [CompletionResult]::new('query', 'query', [CompletionResultType]::ParameterValue, 'Search for a directory in the database')
             [CompletionResult]::new('remove', 'remove', [CompletionResultType]::ParameterValue, 'Remove a directory from the database')
+            [CompletionResult]::new('list', 'list', [CompletionResultType]::ParameterValue, 'List all directory in db')
+            [CompletionResult]::new('clear', 'clear', [CompletionResultType]::ParameterValue, 'Remove  all directory in db')
             break
         }
         'zoxide;add' {
@@ -117,6 +119,20 @@ Register-ArgumentCompleter -Native -CommandName 'zoxide' -ScriptBlock {
             break
         }
         'zoxide;remove' {
+            [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('-V', '-V ', [CompletionResultType]::ParameterName, 'Print version')
+            [CompletionResult]::new('--version', '--version', [CompletionResultType]::ParameterName, 'Print version')
+            break
+        }
+        'zoxide;list' {
+            [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('-V', '-V ', [CompletionResultType]::ParameterName, 'Print version')
+            [CompletionResult]::new('--version', '--version', [CompletionResultType]::ParameterName, 'Print version')
+            break
+        }
+        'zoxide;clear' {
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
             [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
             [CompletionResult]::new('-V', '-V ', [CompletionResultType]::ParameterName, 'Print version')

--- a/contrib/completions/zoxide.bash
+++ b/contrib/completions/zoxide.bash
@@ -15,6 +15,9 @@ _zoxide() {
             zoxide,add)
                 cmd="zoxide__add"
                 ;;
+            zoxide,clear)
+                cmd="zoxide__clear"
+                ;;
             zoxide,edit)
                 cmd="zoxide__edit"
                 ;;
@@ -23,6 +26,9 @@ _zoxide() {
                 ;;
             zoxide,init)
                 cmd="zoxide__init"
+                ;;
+            zoxide,list)
+                cmd="zoxide__list"
                 ;;
             zoxide,query)
                 cmd="zoxide__query"
@@ -49,7 +55,7 @@ _zoxide() {
 
     case "${cmd}" in
         zoxide)
-            opts="-h -V --help --version add edit import init query remove"
+            opts="-h -V --help --version add edit import init query remove list clear"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -77,6 +83,20 @@ _zoxide() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        zoxide__clear)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
                 *)
                     COMPREPLY=()
                     ;;
@@ -187,6 +207,20 @@ _zoxide() {
                     COMPREPLY=($(compgen -W "none prompt pwd" -- "${cur}"))
                     return 0
                     ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        zoxide__list)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
                 *)
                     COMPREPLY=()
                     ;;

--- a/contrib/completions/zoxide.elv
+++ b/contrib/completions/zoxide.elv
@@ -28,6 +28,8 @@ set edit:completion:arg-completer[zoxide] = {|@words|
             cand init 'Generate shell configuration'
             cand query 'Search for a directory in the database'
             cand remove 'Remove a directory from the database'
+            cand list 'List all directory in db'
+            cand clear 'Remove  all directory in db'
         }
         &'zoxide;add'= {
             cand -s 'The rank to increment the entry if it exists or initialize it with if it doesn''t'
@@ -104,6 +106,18 @@ set edit:completion:arg-completer[zoxide] = {|@words|
             cand --version 'Print version'
         }
         &'zoxide;remove'= {
+            cand -h 'Print help'
+            cand --help 'Print help'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'zoxide;list'= {
+            cand -h 'Print help'
+            cand --help 'Print help'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+        &'zoxide;clear'= {
             cand -h 'Print help'
             cand --help 'Print help'
             cand -V 'Print version'

--- a/contrib/completions/zoxide.fish
+++ b/contrib/completions/zoxide.fish
@@ -32,6 +32,8 @@ complete -c zoxide -n "__fish_zoxide_needs_command" -f -a "import" -d 'Import en
 complete -c zoxide -n "__fish_zoxide_needs_command" -f -a "init" -d 'Generate shell configuration'
 complete -c zoxide -n "__fish_zoxide_needs_command" -f -a "query" -d 'Search for a directory in the database'
 complete -c zoxide -n "__fish_zoxide_needs_command" -f -a "remove" -d 'Remove a directory from the database'
+complete -c zoxide -n "__fish_zoxide_needs_command" -f -a "list" -d 'List all directory in db'
+complete -c zoxide -n "__fish_zoxide_needs_command" -f -a "clear" -d 'Remove  all directory in db'
 complete -c zoxide -n "__fish_zoxide_using_subcommand add" -s s -l score -d 'The rank to increment the entry if it exists or initialize it with if it doesn\'t' -r
 complete -c zoxide -n "__fish_zoxide_using_subcommand add" -s h -l help -d 'Print help'
 complete -c zoxide -n "__fish_zoxide_using_subcommand add" -s V -l version -d 'Print version'
@@ -67,3 +69,7 @@ complete -c zoxide -n "__fish_zoxide_using_subcommand query" -s h -l help -d 'Pr
 complete -c zoxide -n "__fish_zoxide_using_subcommand query" -s V -l version -d 'Print version'
 complete -c zoxide -n "__fish_zoxide_using_subcommand remove" -s h -l help -d 'Print help'
 complete -c zoxide -n "__fish_zoxide_using_subcommand remove" -s V -l version -d 'Print version'
+complete -c zoxide -n "__fish_zoxide_using_subcommand list" -s h -l help -d 'Print help'
+complete -c zoxide -n "__fish_zoxide_using_subcommand list" -s V -l version -d 'Print version'
+complete -c zoxide -n "__fish_zoxide_using_subcommand clear" -s h -l help -d 'Print help'
+complete -c zoxide -n "__fish_zoxide_using_subcommand clear" -s V -l version -d 'Print version'

--- a/contrib/completions/zoxide.ts
+++ b/contrib/completions/zoxide.ts
@@ -273,6 +273,34 @@ const completion: Fig.Spec = {
         template: "folders",
       },
     },
+    {
+      name: "list",
+      description: "List all directory in db",
+      options: [
+        {
+          name: ["-h", "--help"],
+          description: "Print help",
+        },
+        {
+          name: ["-V", "--version"],
+          description: "Print version",
+        },
+      ],
+    },
+    {
+      name: "clear",
+      description: "Remove  all directory in db",
+      options: [
+        {
+          name: ["-h", "--help"],
+          description: "Print help",
+        },
+        {
+          name: ["-V", "--version"],
+          description: "Print version",
+        },
+      ],
+    },
   ],
   options: [
     {

--- a/src/cmd/clear.rs
+++ b/src/cmd/clear.rs
@@ -1,0 +1,39 @@
+use anyhow::Result;
+
+use crate::cmd::{Clear, Remove, Run};
+use crate::db::Database;
+use std::io;
+impl Run for Clear {
+    fn run(&self) -> Result<()> {
+        let db = Database::open()?;
+
+        if db.dirs().len() == 0 {
+            println!("History already clear")
+        }
+
+        let mut path = Remove { paths: Vec::new() };
+
+        for dir in db.dirs() {
+            path.paths.push(dir.path.to_string());
+        }
+
+        println!("Do you want to remove {} elements from history? <Y/N>", path.paths.len());
+
+        let mut buffer = String::new();
+        let stdin = io::stdin();
+        stdin.read_line(&mut buffer)?;
+
+        match buffer.trim().to_lowercase().as_str() {
+            "y" | "yes" => {
+                let _ = path.run()?;
+            }
+
+            "n" | "no" => {
+                println!("Nothing was deleted")
+            }
+            _ => println!("Wrong option use Y, N, Yes, No"),
+        };
+
+        Ok(())
+    }
+}

--- a/src/cmd/cmd.rs
+++ b/src/cmd/cmd.rs
@@ -47,6 +47,8 @@ pub enum Cmd {
     Init(Init),
     Query(Query),
     Remove(Remove),
+    List(List),
+    Clear(Clear),
 }
 
 /// Add a new directory or increment its rank
@@ -198,3 +200,19 @@ pub struct Remove {
     #[clap(value_hint = ValueHint::DirPath)]
     pub paths: Vec<String>,
 }
+
+/// List all directory in db
+#[derive(Debug, Parser)]
+#[clap(
+    author,
+    help_template = HelpTemplate,
+)]
+pub struct List {}
+
+/// Remove  all directory in db
+#[derive(Debug, Parser)]
+#[clap(
+    author,
+    help_template = HelpTemplate,
+)]
+pub struct Clear {}

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -1,0 +1,20 @@
+use anyhow::Result;
+
+use crate::cmd::{List, Run};
+use crate::db::Database;
+
+impl Run for List {
+    fn run(&self) -> Result<()> {
+        let db = Database::open()?;
+
+        if db.dirs().len() == 0 {
+            println!("No directory yet!")
+        }
+
+        for dir in db.dirs() {
+            println!("{}", format!("{} {}", dir.rank, dir.path))
+        }
+
+        Ok(())
+    }
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -5,6 +5,8 @@ mod import;
 mod init;
 mod query;
 mod remove;
+mod clear;
+mod list;
 
 use anyhow::Result;
 
@@ -23,6 +25,8 @@ impl Run for Cmd {
             Cmd::Init(cmd) => cmd.run(),
             Cmd::Query(cmd) => cmd.run(),
             Cmd::Remove(cmd) => cmd.run(),
+            Cmd::List(cmd) => cmd.run(),
+            Cmd::Clear(cmd) => cmd.run(),
         }
     }
 }


### PR DESCRIPTION
# list:
the list command provide list of entries in the db example 
``` Bash
# get all the directories in db
zoxide list 
```
this command can be used to backup data 
``` Bash
# get all the directories in db
zoxide list > x.txt 
```
# clear:
delete all entries in db after confirming from the user

# txt import support: 
zoxide import --from=txt x.txt


