### PR TITLE
Provide jump commands completion for nushell

### DIFF
--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -55,8 +55,25 @@ export-env {
 # When using zoxide with --no-cmd, alias these internal functions as desired.
 #
 
+# Provide suitable completion for zoxide jump commands
+def zoxide_completer [context: string] {
+      let query = $context | split row " " | slice 1..
+      let matches = zoxide query -l ...$query | lines | where {|x| $x != $env.PWD}
+      let completions = $matches | if ($in | is-not-empty) { $in } else { null }
+
+      {
+        options: {
+            case_sensitive: false,
+            completion_algorithm: fuzzy,
+            positional: false,
+            sort: false,
+        },
+        completions: $completions
+    }
+}
+
 # Jump to a directory using only keywords.
-def --env --wrapped __zoxide_z [...rest: string] {
+def --env --wrapped __zoxide_z [...rest: string@zoxide_completer] {
   let path = match $rest {
     [] => {'~'},
     [ '-' ] => {'-'},
@@ -72,7 +89,7 @@ def --env --wrapped __zoxide_z [...rest: string] {
 }
 
 # Jump to a directory using interactive search.
-def --env --wrapped __zoxide_zi [...rest:string] {
+def --env --wrapped __zoxide_zi [...rest:string@zoxide_completer] {
   cd $'(^zoxide query --interactive -- ...$rest | str trim -r -c "\n")'
 {%- if echo %}
   echo $env.PWD


### PR DESCRIPTION
For custom commands (defined in Nushell itself), completion has to be directly attached to the command definition
https://www.nushell.sh/book/custom_completions.html#custom-completions

So, better to provide completion in the template itself :)

---

Notice that there is an entire section in the official docs of Nushell discussing zoxide completion
https://www.nushell.sh/cookbook/external_completers.html#zoxide-completer

However,
> This completer is not usable for almost every other command, so it's recommended to add it as an override in the [multiple completer](https://www.nushell.sh/cookbook/external_completers.html#multiple-completer):
> [...]
> Sometimes, a single ***external*** completer is not flexible enough.

i.e., it always assumes that zoxide commands are provided as external ones. While the Nushell template is defining `__zoxide_z` and `__zoxide_zi` as custom commands (internal ones).