### PR TITLE
Add support for multi digits dirstack entry (e.g. +12).

### DIFF
--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -84,7 +84,7 @@ function __zoxide_z() {
     __zoxide_doctor
     if [[ "$#" -eq 0 ]]; then
         __zoxide_cd ~
-    elif [[ "$#" -eq 1 ]] && { [[ -d "$1" ]] || [[ "$1" = '-' ]] || [[ "$1" =~ ^[-+][0-9]$ ]]; }; then
+    elif [[ "$#" -eq 1 ]] && { [[ -d "$1" ]] || [[ "$1" = '-' ]] || [[ "$1" =~ ^[-+][0-9]+$ ]]; }; then
         __zoxide_cd "$1"
     elif [[ "$#" -eq 2 ]] && [[ "$1" = "--" ]]; then
         __zoxide_cd "$2"


### PR DESCRIPTION
In zsh, a dirstack entry with multiple digits will fail even if the dirstack entries are more than that index.
```
❯ dirs -v
0    ~/
1    ~/XXX/YY
...
11    ~/ZZ/CC
12    ~/AAA
...
❯ z +12
zoxide: no match found
```
This corrects this failure by allowing a multi-digit entry index.

Fixes #1074