### PR TITLE
Update rstest from 0.25 to 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,19 +623,18 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rstest"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
  "rstest_macros",
- "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ color-print = "0.3.4"
 
 [dev-dependencies]
 assert_cmd = "2.0.0"
-rstest = { version = "0.25.0", default-features = false }
+rstest = { version = "0.26.0", default-features = false }
 rstest_reuse = "0.7.0"
 tempfile = "=3.15.0"
 


### PR DESCRIPTION
I verified that `cargo test` still works.

https://github.com/la10736/rstest/blob/v0.26.1/CHANGELOG.md