### PR TITLE
feat: allow relative paths for --base-dir

### DIFF
--- a/contrib/completions/_zoxide
+++ b/contrib/completions/_zoxide
@@ -120,7 +120,7 @@ _arguments "${_arguments_options[@]}" : \
 (query)
 _arguments "${_arguments_options[@]}" : \
 '--exclude=[Exclude the current directory]:path:_files -/' \
-'--base-dir=[Only search within this directory]:path:_files -/' \
+'--base-dir=[Only search within this directory (does not check if the path exists)]:path:_files -/' \
 '-a[Show unavailable directories]' \
 '--all[Show unavailable directories]' \
 '(-l --list)-i[Use interactive selection]' \

--- a/contrib/completions/_zoxide.ps1
+++ b/contrib/completions/_zoxide.ps1
@@ -102,7 +102,7 @@ Register-ArgumentCompleter -Native -CommandName 'zoxide' -ScriptBlock {
         }
         'zoxide;query' {
             [CompletionResult]::new('--exclude', '--exclude', [CompletionResultType]::ParameterName, 'Exclude the current directory')
-            [CompletionResult]::new('--base-dir', '--base-dir', [CompletionResultType]::ParameterName, 'Only search within this directory')
+            [CompletionResult]::new('--base-dir', '--base-dir', [CompletionResultType]::ParameterName, 'Only search within this directory (does not check if the path exists)')
             [CompletionResult]::new('-a', '-a', [CompletionResultType]::ParameterName, 'Show unavailable directories')
             [CompletionResult]::new('--all', '--all', [CompletionResultType]::ParameterName, 'Show unavailable directories')
             [CompletionResult]::new('-i', '-i', [CompletionResultType]::ParameterName, 'Use interactive selection')

--- a/contrib/completions/zoxide.elv
+++ b/contrib/completions/zoxide.elv
@@ -90,7 +90,7 @@ set edit:completion:arg-completer[zoxide] = {|@words|
         }
         &'zoxide;query'= {
             cand --exclude 'Exclude the current directory'
-            cand --base-dir 'Only search within this directory'
+            cand --base-dir 'Only search within this directory (does not check if the path exists)'
             cand -a 'Show unavailable directories'
             cand --all 'Show unavailable directories'
             cand -i 'Use interactive selection'

--- a/contrib/completions/zoxide.fish
+++ b/contrib/completions/zoxide.fish
@@ -62,7 +62,7 @@ complete -c zoxide -n "__fish_zoxide_using_subcommand init" -l no-cmd -d 'Preven
 complete -c zoxide -n "__fish_zoxide_using_subcommand init" -s h -l help -d 'Print help'
 complete -c zoxide -n "__fish_zoxide_using_subcommand init" -s V -l version -d 'Print version'
 complete -c zoxide -n "__fish_zoxide_using_subcommand query" -l exclude -d 'Exclude the current directory' -r -f -a "(__fish_complete_directories)"
-complete -c zoxide -n "__fish_zoxide_using_subcommand query" -l base-dir -d 'Only search within this directory' -r -f -a "(__fish_complete_directories)"
+complete -c zoxide -n "__fish_zoxide_using_subcommand query" -l base-dir -d 'Only search within this directory (does not check if the path exists)' -r -f -a "(__fish_complete_directories)"
 complete -c zoxide -n "__fish_zoxide_using_subcommand query" -s a -l all -d 'Show unavailable directories'
 complete -c zoxide -n "__fish_zoxide_using_subcommand query" -s i -l interactive -d 'Use interactive selection'
 complete -c zoxide -n "__fish_zoxide_using_subcommand query" -s l -l list -d 'List all matching directories'

--- a/contrib/completions/zoxide.nu
+++ b/contrib/completions/zoxide.nu
@@ -82,7 +82,7 @@ module completions {
     --list(-l)                # List all matching directories
     --score(-s)               # Print score with results
     --exclude: path           # Exclude the current directory
-    --base-dir: path          # Only search within this directory
+    --base-dir: path          # Only search within this directory (does not check if the path exists)
     --help(-h)                # Print help
     --version(-V)             # Print version
   ]

--- a/contrib/completions/zoxide.ts
+++ b/contrib/completions/zoxide.ts
@@ -216,7 +216,7 @@ const completion: Fig.Spec = {
         },
         {
           name: "--base-dir",
-          description: "Only search within this directory",
+          description: "Only search within this directory (does not check if the path exists)",
           isRepeatable: true,
           args: {
             name: "base_dir",

--- a/src/cmd/cmd.rs
+++ b/src/cmd/cmd.rs
@@ -188,8 +188,9 @@ pub struct Query {
     pub exclude: Option<String>,
 
     /// Only search within this directory
+    /// (does not check if the path exists)
     #[clap(long, value_hint = ValueHint::DirPath, value_name = "path")]
-    pub base_dir: Option<String>,
+    pub base_dir: Option<PathBuf>,
 }
 
 /// Remove a directory from the database

--- a/src/cmd/query.rs
+++ b/src/cmd/query.rs
@@ -80,7 +80,7 @@ impl Query {
         let mut options = StreamOptions::new(now)
             .with_keywords(self.keywords.iter().map(|s| s.as_str()))
             .with_exclude(config::exclude_dirs()?)
-            .with_base_dir(self.base_dir.clone());
+            .with_base_dir(self.base_dir.clone().map(|p| std::fs::canonicalize(&p).unwrap_or(p)));
         if !self.all {
             let resolve_symlinks = config::resolve_symlinks();
             options = options.with_exists(true).with_resolve_symlinks(resolve_symlinks);

--- a/src/db/stream.rs
+++ b/src/db/stream.rs
@@ -1,6 +1,6 @@
 use std::iter::Rev;
 use std::ops::Range;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::{fs, path};
 
 use glob::Pattern;
@@ -128,7 +128,7 @@ pub struct StreamOptions {
 
     /// Only return directories within this parent directory
     /// Does not check if the path exists
-    base_dir: Option<String>,
+    base_dir: Option<PathBuf>,
 }
 
 impl StreamOptions {
@@ -168,7 +168,7 @@ impl StreamOptions {
         self
     }
 
-    pub fn with_base_dir(mut self, base_dir: Option<String>) -> Self {
+    pub fn with_base_dir(mut self, base_dir: Option<PathBuf>) -> Self {
         self.base_dir = base_dir;
         self
     }


### PR DESCRIPTION
Use std::filesystem::canonicalize to transform to an absolute path.