### PR TITLE
Update Nushell completion

### DIFF
--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -51,12 +51,25 @@ export-env {
 
 {%- endif %}
 
+def "nu-complete zoxide path" [context: string] {
+  let parts = $context | split row " " | skip 1
+  {
+    options: {
+      sort: false
+      completion_algorithm: prefix
+      positional: false
+      case_sensitive: false
+    }
+    completions: (zoxide query --list --exclude $env.PWD -- ...$parts | lines)
+  }
+}
+
 {{ section }}
 # When using zoxide with --no-cmd, alias these internal functions as desired.
 #
 
 # Jump to a directory using only keywords.
-def --env --wrapped __zoxide_z [...rest: string] {
+def --env --wrapped __zoxide_z [...rest: string@"nu-complete zoxide path"] {
   let path = match $rest {
     [] => {'~'},
     [ '-' ] => {'-'},


### PR DESCRIPTION
Fixes #1098.

Nushell [external completers are no longer used for internal commands](https://www.nushell.sh/blog/2025-03-18-nushell_0_103_0.html#external-completers-are-no-longer-used-for-internal-commands-toc) so we should include the completion for commands.
