### PR TITLE
Add an option to disable the existence check

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,10 @@ Environment variables[^2] can be used for configuration. They must be set before
 - `_ZO_RESOLVE_SYMLINKS`
   - When set to 1, `z` will resolve symlinks before adding directories to the
     database.
+- `_ZO_DISABLE_EXISTENCE_CHECK`
+  - When set to 1, `z` will not filter the list for the existing files.
+    This improves the performance when the files on the list are on
+    a slow drive, such as a network drive.
 
 ## Third-party integrations
 

--- a/man/man1/zoxide.1
+++ b/man/man1/zoxide.1
@@ -99,6 +99,11 @@ the database. By default, this is set to 10000.
 .B _ZO_RESOLVE_SYMLINKS
 When set to 1, \fBz\fR will resolve symlinks before adding directories to
 the database.
+.TP
+.B _ZO_DISABLE_EXISTENCE_CHECK
+When set to 1, \fBz\fR will not filter the list for the existing files.
+This improves the performance when the files on the list are on a slow drive,
+such as a network drive.
 .SH ALGORITHM
 .TP
 .B AGING

--- a/src/cmd/cmd.rs
+++ b/src/cmd/cmd.rs
@@ -27,7 +27,8 @@ https://github.com/ajeetdsouza/zoxide
 {tab}<bold>_ZO_EXCLUDE_DIRS</bold>    {tab}List of directory globs to be excluded
 {tab}<bold>_ZO_FZF_OPTS</bold>        {tab}Custom flags to pass to fzf
 {tab}<bold>_ZO_MAXAGE</bold>          {tab}Maximum total age after which entries start getting deleted
-{tab}<bold>_ZO_RESOLVE_SYMLINKS</bold>{tab}Resolve symlinks when storing paths").into_resettable()
+{tab}<bold>_ZO_RESOLVE_SYMLINKS</bold>{tab}Resolve symlinks when storing paths
+{tab}<bold>_ZO_DISABLE_EXISTENCE_CHECK</bold>{tab}Do not filter the list by existing files").into_resettable()
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,3 +60,7 @@ pub fn maxage() -> Result<Rank> {
 pub fn resolve_symlinks() -> bool {
     env::var_os("_ZO_RESOLVE_SYMLINKS").is_some_and(|var| var == "1")
 }
+
+pub fn disable_existence_filter() -> bool {
+    env::var_os("_ZO_DISABLE_EXISTENCE_CHECK").is_some_and(|var| var == "1")
+}

--- a/src/db/stream.rs
+++ b/src/db/stream.rs
@@ -5,6 +5,7 @@ use std::{fs, path};
 
 use glob::Pattern;
 
+use crate::config;
 use crate::db::{Database, Dir, Epoch};
 use crate::util::{self, MONTH};
 
@@ -65,7 +66,7 @@ impl<'a> Stream<'a> {
     }
 
     fn filter_by_exists(&self, path: &str) -> bool {
-        if !self.options.exists {
+        if !self.options.exists || config::disable_existence_filter() {
             return true;
         }
 


### PR DESCRIPTION
PR adds an option to disable filtering by the existing files. The issue with that feature is that, if some files are on a slow medium, like a network drive, accessing them can take a while, slowing down everything significantly.

Files will still eventually get discarded from the database by the aging algorithm, so I consider this a good tradeoff.

After investigating #1044 for a bit, I came to the conclusion that the filtering for the existing files seems to be the culprit. I can't say for certain, but after disabling and running for a while, I could not reproduce the issue anymore.

This fixes #1044