### PR TITLE
Update Zoxide shell setup for Nushell in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,22 +247,14 @@ zoxide can be installed in 4 easy steps:
    <details>
    <summary>Nushell</summary>
 
-   > Add this to the <ins>**end**</ins> of your env file (find it by running `$nu.env-path`
-   > in Nushell):
+   > Add this to the <ins>**end**</ins> of your config file (find it by running `$nu.config-path` in Nushell):
    >
    > ```sh
-   > zoxide init nushell | save -f ~/.zoxide.nu
-   > ```
-   >
-   > Now, add this to the <ins>**end**</ins> of your config file (find it by running
-   > `$nu.config-path` in Nushell):
-   >
-   > ```sh
-   > source ~/.zoxide.nu
+   > zoxide init nushell | save -f ($nu.user-autoload-dirs.0)/zoxide.nu
    > ```
    >
    > **Note**
-   > zoxide only supports Nushell v0.89.0+.
+   > zoxide only supports Nushell v0.96.0+.
 
    </details>
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,8 @@ zoxide can be installed in 4 easy steps:
    <details>
    <summary>Nushell</summary>
 
-   > Add this to the <ins>**end**</ins> of your config file (find it by running `$nu.config-path` in Nushell):
+   > Add this to the <ins>**end**</ins> of your config file.
+   > Find it by running `$nu.config-path` in Nushell:
    >
    > ```sh
    > zoxide init nushell | save -f ($nu.user-autoload-dirs.0)/zoxide.nu

--- a/README.md
+++ b/README.md
@@ -247,22 +247,14 @@ zoxide can be installed in 4 easy steps:
    <details>
    <summary>Nushell</summary>
 
-   > Add this to the <ins>**end**</ins> of your env file (find it by running `$nu.env-path`
-   > in Nushell):
+   > Execute this command:
    >
    > ```sh
-   > zoxide init nushell | save -f ~/.zoxide.nu
-   > ```
-   >
-   > Now, add this to the <ins>**end**</ins> of your config file (find it by running
-   > `$nu.config-path` in Nushell):
-   >
-   > ```sh
-   > source ~/.zoxide.nu
+   > zoxide init nushell | save -f ~/.config/nushell/autoload/zoxide.nu
    > ```
    >
    > **Note**
-   > zoxide only supports Nushell v0.89.0+.
+   > zoxide only supports Nushell v0.96.0+.
 
    </details>
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ zoxide can be installed in 4 easy steps:
    > Execute this command:
    >
    > ```sh
-   > zoxide init nushell | save -f ~/.config/nushell/autoload/zoxide.nu
+   > zoxide init nushell | save -f ($nu.user-autoload-dirs.0)/zoxide.nu
    > ```
    >
    > **Note**

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ zoxide can be installed in 4 easy steps:
    > Execute this command:
    >
    > ```sh
-   > zoxide init nushell | save -f ($nu.user-autoload-dirs.0)/zoxide.nu
+   > zoxide init nushell | save -f ~/.config/nushell/autoload/zoxide.nu
    > ```
    >
    > **Note**

--- a/README.md
+++ b/README.md
@@ -247,14 +247,22 @@ zoxide can be installed in 4 easy steps:
    <details>
    <summary>Nushell</summary>
 
-   > Execute this command:
+   > Add this to the <ins>**end**</ins> of your env file (find it by running `$nu.env-path`
+   > in Nushell):
    >
    > ```sh
-   > zoxide init nushell | save -f ~/.config/nushell/autoload/zoxide.nu
+   > zoxide init nushell | save -f ~/.zoxide.nu
+   > ```
+   >
+   > Now, add this to the <ins>**end**</ins> of your config file (find it by running
+   > `$nu.config-path` in Nushell):
+   >
+   > ```sh
+   > source ~/.zoxide.nu
    > ```
    >
    > **Note**
-   > zoxide only supports Nushell v0.96.0+.
+   > zoxide only supports Nushell v0.89.0+.
 
    </details>
 


### PR DESCRIPTION
**Auto-load** files support was added on **Nushell** [v0.96.0](https://www.nushell.sh/blog/2024-07-23-nushell_0_96_0.html), allowing `nu` files to be **auto-loaded** on shell start. This behavior is documented [here](https://www.nushell.sh/book/configuration.html#configuration-overview).

This **PR** replaces the need of have a separate file and source it *"manually"*. Instead, **Zoxide** completions now can be added with one-line command.

Also, **Zoxide** now requires [v0.96.0+](https://www.nushell.sh/blog/2024-07-23-nushell_0_96_0.html) as minimum  **Nushell** version.