### PR TITLE
Add colors to --help/-h

### DIFF
--- a/src/cmd/cmd.rs
+++ b/src/cmd/cmd.rs
@@ -2,7 +2,8 @@
 
 use std::path::PathBuf;
 
-use clap::builder::{IntoResettable, Resettable, StyledStr};
+use clap::builder::styling::{AnsiColor, Effects};
+use clap::builder::{IntoResettable, Resettable, StyledStr, Styles};
 use clap::{Parser, Subcommand, ValueEnum, ValueHint};
 
 struct HelpTemplate;
@@ -31,6 +32,12 @@ https://github.com/ajeetdsouza/zoxide
     }
 }
 
+const STYLES: Styles = Styles::styled()
+    .header(AnsiColor::Yellow.on_default().effects(Effects::BOLD))
+    .usage(AnsiColor::Green.on_default().effects(Effects::BOLD))
+    .literal(AnsiColor::Green.on_default().effects(Effects::BOLD))
+    .placeholder(AnsiColor::Green.on_default());
+
 #[derive(Debug, Parser)]
 #[clap(
     about,
@@ -39,6 +46,7 @@ https://github.com/ajeetdsouza/zoxide
     disable_help_subcommand = true,
     propagate_version = true,
     version,
+    styles = STYLES,
 )]
 pub enum Cmd {
     Add(Add),


### PR DESCRIPTION
User can disable colors via `NO_COLOR=1` environment variable if needed

Output of `zoxide --help`:
| before | after | `NO_COLOR=1` |
| - | - | - |
| <img width="865" height="576" alt="zoxide-before" src="https://github.com/user-attachments/assets/32389a73-4452-48fe-bc43-574b1767e63d" /> | <img width="865" height="576" alt="zoxide-colors" src="https://github.com/user-attachments/assets/3a34c7db-49e0-4b37-89d0-ed586da0662e" /> | <img width="865" height="576" alt="zoxide-no-color" src="https://github.com/user-attachments/assets/4bc4e617-75c2-40a2-aab6-2ea3784ed0df" /> |