### PR TITLE
-z to pick  up ~HOME

### DIFF
--- a/src/cmd/query.rs
+++ b/src/cmd/query.rs
@@ -8,6 +8,17 @@ use crate::db::{Database, Epoch, Stream, StreamOptions};
 use crate::error::BrokenPipeHandler;
 use crate::util::{self, Fzf, FzfChild};
 
+fn expand_tilde(path: &str) -> String {
+    if let Some(stripped) = path.strip_prefix('~') {
+        if let Some(home) = dirs::home_dir() {
+            if let Some(home_str) = home.to_str() {
+                return format!("{}{}", home_str, stripped);
+            }
+        }
+    }
+    path.to_string()
+}
+
 impl Run for Query {
     fn run(&self) -> Result<()> {
         let mut db = crate::db::Database::open()?;
@@ -47,7 +58,8 @@ impl Query {
             print!("{selection}");
         } else {
             let path = selection.get(7..).context("could not read selection from fzf")?;
-            print!("{path}");
+            let expanded_path = expand_tilde(path);
+            print!("{expanded_path}");
         }
         Ok(())
     }

--- a/src/db/dir.rs
+++ b/src/db/dir.rs
@@ -5,6 +5,21 @@ use serde::{Deserialize, Serialize};
 
 use crate::util::{DAY, HOUR, WEEK};
 
+fn path_with_tilde(path: &str) -> Cow<'_, str> {
+    if let Some(home) = dirs::home_dir() {
+        if let Some(home_str) = home.to_str() {
+            if let Some(suffix) = path.strip_prefix(home_str) {
+                if suffix.is_empty() {
+                    return Cow::Borrowed("~");
+                } else if suffix.starts_with('/') || suffix.starts_with('\\') {
+                    return Cow::Owned(format!("~{}", suffix));
+                }
+            }
+        }
+    }
+    Cow::Borrowed(path)
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Dir<'a> {
     #[serde(borrow)]
@@ -61,7 +76,7 @@ impl Display for DirDisplay<'_> {
             let score = self.dir.score(now).clamp(0.0, 9999.0);
             write!(f, "{score:>6.1}{}", self.separator)?;
         }
-        write!(f, "{}", self.dir.path)
+        write!(f, "{}", path_with_tilde(&self.dir.path))
     }
 }
 


### PR DESCRIPTION
fixes #1161

Before: When you used the fzf selector, paths in your home directory showed like this:

/home/yourname/Documents
/home/yourname/Downloads
/home/yourname/projects/foo
After: Now they show like this:

~/Documents
~/Downloads
~/projects/foo
How I did it:

When displaying paths → replace your home directory part with ~ When you select a path → convert ~ back to the full path before using it So it's just cleaner to read in the fzf menu, but everything still works the same way behind the scenes.