### PR TITLE
fish: clear existing completions before defining aliases

### DIFF
--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -117,9 +117,11 @@ end
 {%- when Some with (cmd) %}
 
 abbr --erase {{cmd}} &>/dev/null
+complete --erase --command {{cmd}}
 alias {{cmd}}=__zoxide_z
 
 abbr --erase {{cmd}}i &>/dev/null
+complete --erase --command {{cmd}}i
 alias {{cmd}}i=__zoxide_zi
 
 {%- when None %}


### PR DESCRIPTION
Fish ships with built-in completions for common commands like `j` (for autojump): https://github.com/fish-shell/fish-shell/blob/master/share/completions/j.fish

When using `zoxide init --cmd j fish`, these completions override zoxide's and break directory completion.

This PR clears existing completions before defining aliases, so zoxide's completions take effect.