### PR TITLE
fix issue #1166

### DIFF
--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -84,7 +84,7 @@ function __zoxide_z() {
     __zoxide_doctor
     if [[ "$#" -eq 0 ]]; then
         __zoxide_cd ~
-    elif [[ "$#" -eq 1 ]] && { [[ -d "$1" ]] || [[ "$1" = '-' ]] || [[ "$1" =~ ^[-+][0-9]+$ ]]; }; then
+    elif [[ "$#" -eq 1 ]] && { [[ -d "$(realpath -L "$PWD"/"$1")" ]] || [[ "$1" = '-' ]] || [[ "$1" =~ ^[-+][0-9]+$ ]]; }; then
         __zoxide_cd "$1"
     elif [[ "$#" -eq 2 ]] && [[ "$1" = "--" ]]; then
         __zoxide_cd "$2"


### PR DESCRIPTION
This PR fixes issue #1166 by using `realpath -L` to expand `..` before symlinks when detecting whether a target path is a directory or not.