### PR TITLE
fix(completions): keep input on empty interactive selection

### DIFF
--- a/src/cmd/query.rs
+++ b/src/cmd/query.rs
@@ -1,11 +1,11 @@
 use std::io::{self, Write};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 
 use crate::cmd::{Query, Run};
 use crate::config;
 use crate::db::{Database, Epoch, Stream, StreamOptions};
-use crate::error::BrokenPipeHandler;
+use crate::error::{BrokenPipeHandler, SilentExit};
 use crate::util::{self, Fzf, FzfChild};
 
 impl Run for Query {
@@ -31,16 +31,23 @@ impl Query {
 
     fn query_interactive(&self, stream: &mut Stream, now: Epoch) -> Result<()> {
         let mut fzf = Self::get_fzf()?;
-        let selection = loop {
-            match stream.next() {
-                Some(dir) if Some(dir.path.as_ref()) == self.exclude.as_deref() => continue,
-                Some(dir) => {
-                    if let Some(selection) = fzf.write(dir, now)? {
-                        break selection;
+        let selection = match (|| -> Result<String> {
+            loop {
+                match stream.next() {
+                    Some(dir) if Some(dir.path.as_ref()) == self.exclude.as_deref() => continue,
+                    Some(dir) => {
+                        if let Some(selection) = fzf.write(dir, now)? {
+                            break Ok(selection);
+                        }
                     }
+                    None => break fzf.wait(),
                 }
-                None => break fzf.wait()?,
             }
+        })() {
+            Ok(selection) if selection.is_empty() => bail!(SilentExit { code: 1 }),
+            Ok(selection) => selection,
+            Err(err) if err.to_string() == "no match found" => bail!(SilentExit { code: 1 }),
+            Err(err) => return Err(err),
         };
 
         if self.score {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -66,7 +66,12 @@ mod tests {
     }
 
     #[apply(opts)]
-    fn bash_init_guards_empty_completion(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
+    fn bash_init_guards_empty_completion(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+    ) {
         let opts = Opts { cmd, hook, echo, resolve_symlinks };
         let source = Bash(&opts).render().unwrap();
         assert!(source.contains("[[ -n \"${__zoxide_result}\" ]] || return"));
@@ -149,7 +154,12 @@ mod tests {
     }
 
     #[apply(opts)]
-    fn fish_init_guards_empty_completion(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
+    fn fish_init_guards_empty_completion(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+    ) {
         let opts = Opts { cmd, hook, echo, resolve_symlinks };
         let source = Fish(&opts).render().unwrap();
         assert!(source.contains("and test -n \"$result\""));

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -74,7 +74,7 @@ mod tests {
     ) {
         let opts = Opts { cmd, hook, echo, resolve_symlinks };
         let source = Bash(&opts).render().unwrap();
-        assert!(source.contains("[[ -n \"${__zoxide_result}\" ]] || return"));
+        assert!(source.contains("[[ -n ${__zoxide_result} ]] || return"));
     }
 
     #[apply(opts)]

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -66,6 +66,13 @@ mod tests {
     }
 
     #[apply(opts)]
+    fn bash_init_guards_empty_completion(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+        let source = Bash(&opts).render().unwrap();
+        assert!(source.contains("[[ -n \"${__zoxide_result}\" ]] || return"));
+    }
+
+    #[apply(opts)]
     fn bash_shellcheck(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
         let opts = Opts { cmd, hook, echo, resolve_symlinks };
         let source = Bash(&opts).render().unwrap();
@@ -139,6 +146,13 @@ mod tests {
             .success()
             .stdout("")
             .stderr("");
+    }
+
+    #[apply(opts)]
+    fn fish_init_guards_empty_completion(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+        let source = Fish(&opts).render().unwrap();
+        assert!(source.contains("and test -n \"$result\""));
     }
 
     #[apply(opts)]

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -74,7 +74,11 @@ mod tests {
     ) {
         let opts = Opts { cmd, hook, echo, resolve_symlinks };
         let source = Bash(&opts).render().unwrap();
-        assert!(source.contains("[[ -n ${__zoxide_result} ]] || return"));
+        if cmd.is_some() {
+            assert!(source.contains("[[ -n ${__zoxide_result} ]] || return"));
+        } else {
+            assert!(!source.contains("[[ -n ${__zoxide_result} ]] || return"));
+        }
     }
 
     #[apply(opts)]

--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -179,7 +179,7 @@ if [[ ${BASH_VERSINFO[0]:-0} -eq 4 && ${BASH_VERSINFO[1]:-0} -ge 4 || ${BASH_VER
         elif [[ -z ${COMP_WORDS[-1]} ]]; then
             # shellcheck disable=SC2312
             __zoxide_result="$(\command zoxide query --exclude "$(__zoxide_pwd)" --interactive -- "{{ "${COMP_WORDS[@]:1:${#COMP_WORDS[@]}-2}" }}")" || return
-            [[ -n "${__zoxide_result}" ]] || return
+            [[ -n ${__zoxide_result} ]] || return
 
             # In case the terminal does not respond to \e[5n or another
             # mechanism steals the response, it is still worth completing

--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -178,18 +178,19 @@ if [[ ${BASH_VERSINFO[0]:-0} -eq 4 && ${BASH_VERSINFO[1]:-0} -ge 4 || ${BASH_VER
         # If there is a space after the last word, use interactive selection.
         elif [[ -z ${COMP_WORDS[-1]} ]]; then
             # shellcheck disable=SC2312
-            __zoxide_result="$(\command zoxide query --exclude "$(__zoxide_pwd)" --interactive -- "{{ "${COMP_WORDS[@]:1:${#COMP_WORDS[@]}-2}" }}")" && {
-                # In case the terminal does not respond to \e[5n or another
-                # mechanism steals the response, it is still worth completing
-                # the directory in the command line.
-                COMPREPLY=("${__zoxide_z_prefix}${__zoxide_result}/")
+            __zoxide_result="$(\command zoxide query --exclude "$(__zoxide_pwd)" --interactive -- "{{ "${COMP_WORDS[@]:1:${#COMP_WORDS[@]}-2}" }}")" || return
+            [[ -n "${__zoxide_result}" ]] || return
 
-                # Note: We here call "bind" without prefixing "\builtin" to be
-                # compatible with frameworks like ble.sh, which emulates Bash's
-                # builtin "bind".
-                bind -x '"\e[0n": __zoxide_z_complete_helper'
-                \builtin printf '\e[5n' >/dev/tty
-            }
+            # In case the terminal does not respond to \e[5n or another
+            # mechanism steals the response, it is still worth completing
+            # the directory in the command line.
+            COMPREPLY=("${__zoxide_z_prefix}${__zoxide_result}/")
+
+            # Note: We here call "bind" without prefixing "\builtin" to be
+            # compatible with frameworks like ble.sh, which emulates Bash's
+            # builtin "bind".
+            bind -x '"\e[0n": __zoxide_z_complete_helper'
+            \builtin printf '\e[5n' >/dev/tty
         fi
     }
 

--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -101,6 +101,7 @@ function __zoxide_z_complete
         # If the last argument is empty, use interactive selection.
         set -l query $tokens[2..-1]
         set -l result (command zoxide query --exclude (__zoxide_pwd) --interactive -- $query)
+        and test -n "$result"
         and __zoxide_cd $result
         and builtin commandline --function cancel-commandline repaint
     end

--- a/tests/query_interactive.rs
+++ b/tests/query_interactive.rs
@@ -1,0 +1,50 @@
+#![cfg(not(windows))]
+
+use std::env;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+
+use assert_cmd::Command;
+
+fn fake_path(script: &str) -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("fzf");
+    fs::write(&path, script).unwrap();
+    let mut perms = fs::metadata(&path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&path, perms).unwrap();
+    let path_env = format!("{}:{}", dir.path().display(), env::var("PATH").unwrap_or_default());
+    (dir, path_env)
+}
+
+#[test]
+fn interactive_query_is_silent_when_fzf_reports_no_match() {
+    let home = tempfile::tempdir().unwrap();
+    let (_bin_dir, path_env) = fake_path("#!/bin/sh\ncat >/dev/null\nexit 1\n");
+
+    Command::cargo_bin("zoxide")
+        .unwrap()
+        .env("HOME", home.path())
+        .env("PATH", path_env)
+        .args(["query", "--interactive"])
+        .assert()
+        .code(1)
+        .stdout("")
+        .stderr("");
+}
+
+#[test]
+fn interactive_query_is_silent_when_fzf_returns_empty_output() {
+    let home = tempfile::tempdir().unwrap();
+    let (_bin_dir, path_env) = fake_path("#!/bin/sh\ncat >/dev/null\nexit 0\n");
+
+    Command::cargo_bin("zoxide")
+        .unwrap()
+        .env("HOME", home.path())
+        .env("PATH", path_env)
+        .args(["query", "--interactive"])
+        .assert()
+        .code(1)
+        .stdout("")
+        .stderr("");
+}

--- a/tests/query_interactive.rs
+++ b/tests/query_interactive.rs
@@ -1,8 +1,7 @@
 #![cfg(not(windows))]
 
-use std::env;
-use std::fs;
 use std::os::unix::fs::PermissionsExt;
+use std::{env, fs};
 
 use assert_cmd::Command;
 


### PR DESCRIPTION
## Summary
- guard bash interactive completion so it only rewrites the line when a selection is non-empty
- guard fish interactive completion to only cancel/replace on non-empty selection
- add init-output checks to ensure the guards are present

## Testing
- not run (read-only environment)

Refs #766
