### PR TITLE
Jump to child shell shortcut

### DIFF
--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -134,6 +134,43 @@ function __zoxide_zi() {
     result="$(\command zoxide query --interactive -- "$@")" && __zoxide_cd "${result}"
 }
 
+# Jump to a directory within the current directory.
+function __zoxide_zc() {
+    __zoxide_doctor
+
+    # shellcheck disable=SC2199
+    if [[ $# -eq 0 ]]; then
+        __zoxide_cd ~
+    elif [[ $# -eq 1 && $1 == '-' ]]; then
+        __zoxide_cd "${OLDPWD}"
+    elif [[ $# -eq 1 && -d $1 ]]; then
+        __zoxide_cd "$1"
+    elif [[ $# -eq 2 && $1 == '--' ]]; then
+        __zoxide_cd "$2"
+    elif [[ ${@: -1} == "${__zoxide_z_prefix}"?* ]]; then
+        # shellcheck disable=SC2124
+        \builtin local result="${@: -1}"
+        __zoxide_cd "{{ "${result:${#__zoxide_z_prefix}}" }}"
+    else
+        \builtin local base_dir
+        \builtin local result
+        base_dir="$(__zoxide_pwd)"
+        # shellcheck disable=SC2312
+        result="$(\command zoxide query --exclude "${base_dir}" --base-dir "${base_dir}" -- "$@")" &&
+            __zoxide_cd "${result}"
+    fi
+}
+
+# Jump to a directory within the current directory using interactive search.
+function __zoxide_zci() {
+    __zoxide_doctor
+    \builtin local base_dir
+    \builtin local result
+    base_dir="$(__zoxide_pwd)"
+    result="$(\command zoxide query --interactive --base-dir "${base_dir}" -- "$@")" &&
+        __zoxide_cd "${result}"
+}
+
 {{ section }}
 # Commands for zoxide. Disable these using --no-cmd.
 #
@@ -149,6 +186,16 @@ function {{cmd}}() {
 \builtin unalias {{cmd}}i &>/dev/null || \builtin true
 function {{cmd}}i() {
     __zoxide_zi "$@"
+}
+
+\builtin unalias {{cmd}}c &>/dev/null || \builtin true
+function {{cmd}}c() {
+    __zoxide_zc "$@"
+}
+
+\builtin unalias {{cmd}}ci &>/dev/null || \builtin true
+function {{cmd}}ci() {
+    __zoxide_zci "$@"
 }
 
 # Load completions.

--- a/templates/elvish.txt
+++ b/templates/elvish.txt
@@ -76,6 +76,40 @@ fn __zoxide_zi {|@rest|
 }
 edit:add-var __zoxide_zi~ $__zoxide_zi~
 
+# Jump to a directory within the current directory.
+fn __zoxide_zc {|@rest|
+    var base_dir = $pwd
+    if (builtin:eq [] $rest) {
+        __zoxide_cd ~
+    } elif (builtin:eq [-] $rest) {
+        __zoxide_cd $oldpwd
+    } elif (and ('builtin:==' (builtin:count $rest) 1) (path:is-dir &follow-symlink=$true $rest[0])) {
+        __zoxide_cd $rest[0]
+    } else {
+        var path
+        try {
+            set path = (zoxide query --exclude $base_dir --base-dir $base_dir -- $@rest)
+        } catch {
+        } else {
+            __zoxide_cd $path
+        }
+    }
+}
+edit:add-var __zoxide_zc~ $__zoxide_zc~
+
+# Jump to a directory within the current directory using interactive search.
+fn __zoxide_zci {|@rest|
+    var base_dir = $pwd
+    var path
+    try {
+        set path = (zoxide query --interactive --base-dir $base_dir -- $@rest)
+    } catch {
+    } else {
+        __zoxide_cd $path
+    }
+}
+edit:add-var __zoxide_zci~ $__zoxide_zci~
+
 {{ section }}
 # Commands for zoxide. Disable these using --no-cmd.
 #
@@ -85,6 +119,8 @@ edit:add-var __zoxide_zi~ $__zoxide_zi~
 
 edit:add-var {{cmd}}~ $__zoxide_z~
 edit:add-var {{cmd}}i~ $__zoxide_zi~
+edit:add-var {{cmd}}c~ $__zoxide_zc~
+edit:add-var {{cmd}}ci~ $__zoxide_zci~
 
 # Load completions.
 {#-

--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -113,6 +113,31 @@ function __zoxide_zi
     and __zoxide_cd $result
 end
 
+# Jump to a directory within the current directory.
+function __zoxide_zc
+    set -l base_dir (__zoxide_pwd)
+    set -l argc (builtin count $argv)
+    if test $argc -eq 0
+        __zoxide_cd $HOME
+    else if test "$argv" = -
+        __zoxide_cd -
+    else if test $argc -eq 1 -a -d $argv[1]
+        __zoxide_cd $argv[1]
+    else if test $argc -eq 2 -a $argv[1] = --
+        __zoxide_cd -- $argv[2]
+    else
+        set -l result (command zoxide query --exclude $base_dir --base-dir $base_dir -- $argv)
+        and __zoxide_cd $result
+    end
+end
+
+# Jump to a directory within the current directory using interactive search.
+function __zoxide_zci
+    set -l base_dir (__zoxide_pwd)
+    set -l result (command zoxide query --interactive --base-dir $base_dir -- $argv)
+    and __zoxide_cd $result
+end
+
 {{ section }}
 # Commands for zoxide. Disable these using --no-cmd.
 #
@@ -127,6 +152,14 @@ alias {{cmd}}=__zoxide_z
 abbr --erase {{cmd}}i &>/dev/null
 complete --erase --command {{cmd}}i
 alias {{cmd}}i=__zoxide_zi
+
+abbr --erase {{cmd}}c &>/dev/null
+complete --erase --command {{cmd}}c
+alias {{cmd}}c=__zoxide_zc
+
+abbr --erase {{cmd}}ci &>/dev/null
+complete --erase --command {{cmd}}ci
+alias {{cmd}}ci=__zoxide_zci
 
 {%- when None %}
 

--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -79,6 +79,32 @@ def --env --wrapped __zoxide_zi [...rest:string] {
 {%- endif %}
 }
 
+# Jump to a directory within the current directory.
+def --env --wrapped __zoxide_zc [...rest: string] {
+  let base_dir = $env.PWD
+  let path = match $rest {
+    [] => {'~'},
+    [ '-' ] => {'-'},
+    [ $arg ] if ($arg | path expand | path type) == 'dir' => {$arg}
+    _ => {
+      ^zoxide query --exclude $base_dir --base-dir $base_dir -- ...$rest | str trim -r -c "\n"
+    }
+  }
+  cd $path
+{%- if echo %}
+  echo $env.PWD
+{%- endif %}
+}
+
+# Jump to a directory within the current directory using interactive search.
+def --env --wrapped __zoxide_zci [...rest:string] {
+  let base_dir = $env.PWD
+  cd $'(^zoxide query --interactive --base-dir ($base_dir) -- ...$rest | str trim -r -c "\n")'
+{%- if echo %}
+  echo $env.PWD
+{%- endif %}
+}
+
 {{ section }}
 # Commands for zoxide. Disable these using --no-cmd.
 #
@@ -88,6 +114,8 @@ def --env --wrapped __zoxide_zi [...rest:string] {
 
 alias {{cmd}} = __zoxide_z
 alias {{cmd}}i = __zoxide_zi
+alias {{cmd}}c = __zoxide_zc
+alias {{cmd}}ci = __zoxide_zci
 
 {%- when None %}
 

--- a/templates/posix.txt
+++ b/templates/posix.txt
@@ -119,6 +119,37 @@ __zoxide_zi() {
     __zoxide_result="$(\command zoxide query --interactive -- "$@")" && __zoxide_cd "${__zoxide_result}"
 }
 
+# Jump to a directory within the current directory.
+__zoxide_zc() {
+    __zoxide_doctor
+
+    if [ "$#" -eq 0 ]; then
+        __zoxide_cd ~
+    elif [ "$#" -eq 1 ] && [ "$1" = '-' ]; then
+        if [ -n "${OLDPWD}" ]; then
+            __zoxide_cd "${OLDPWD}"
+        else
+            # shellcheck disable=SC2016
+            \command printf 'zoxide: $OLDPWD is not set'
+            return 1
+        fi
+    elif [ "$#" -eq 1 ] && [ -d "$1" ]; then
+        __zoxide_cd "$1"
+    else
+        __zoxide_base="$(__zoxide_pwd || \command true)"
+        __zoxide_result="$(\command zoxide query --exclude "${__zoxide_base}" --base-dir "${__zoxide_base}" -- "$@")" &&
+            __zoxide_cd "${__zoxide_result}"
+    fi
+}
+
+# Jump to a directory within the current directory using interactive search.
+__zoxide_zci() {
+    __zoxide_doctor
+    __zoxide_base="$(__zoxide_pwd || \command true)"
+    __zoxide_result="$(\command zoxide query --interactive --base-dir "${__zoxide_base}" -- "$@")" &&
+        __zoxide_cd "${__zoxide_result}"
+}
+
 {{ section }}
 # Commands for zoxide. Disable these using --no-cmd.
 #
@@ -134,6 +165,16 @@ __zoxide_zi() {
 \command unalias {{cmd}}i >/dev/null 2>&1 || \true
 {{cmd}}i() {
     __zoxide_zi "$@"
+}
+
+\command unalias {{cmd}}c >/dev/null 2>&1 || \true
+{{cmd}}c() {
+    __zoxide_zc "$@"
+}
+
+\command unalias {{cmd}}ci >/dev/null 2>&1 || \true
+{{cmd}}ci() {
+    __zoxide_zci "$@"
 }
 
 {%- when None %}

--- a/templates/powershell.txt
+++ b/templates/powershell.txt
@@ -134,6 +134,45 @@ function global:__zoxide_zi {
     }
 }
 
+# Jump to a directory within the current directory.
+function global:__zoxide_zc {
+    if ($args.Length -eq 0) {
+        __zoxide_cd $HOME $false
+    }
+    elseif ($args.Length -eq 1 -and $args[0] -eq '-') {
+        __zoxide_cd $args[0] $true
+    }
+    elseif ($args.Length -eq 1 -and (Test-Path -PathType Container -Path $args[0] )) {
+        __zoxide_cd $args[0] $false
+    }
+    else {
+        $baseDir = __zoxide_pwd
+        if ($null -ne $baseDir) {
+            $result = __zoxide_bin query --exclude $baseDir --base-dir $baseDir "--" @args
+        }
+        else {
+            $result = __zoxide_bin query "--" @args
+        }
+        if ($LASTEXITCODE -eq 0) {
+            __zoxide_cd $result $true
+        }
+    }
+}
+
+# Jump to a directory within the current directory using interactive search.
+function global:__zoxide_zci {
+    $baseDir = __zoxide_pwd
+    if ($null -ne $baseDir) {
+        $result = __zoxide_bin query -i --base-dir $baseDir "--" @args
+    }
+    else {
+        $result = __zoxide_bin query -i "--" @args
+    }
+    if ($LASTEXITCODE -eq 0) {
+        __zoxide_cd $result $true
+    }
+}
+
 {{ section }}
 # Commands for zoxide. Disable these using --no-cmd.
 #
@@ -143,6 +182,8 @@ function global:__zoxide_zi {
 
 Set-Alias -Name {{cmd}} -Value __zoxide_z -Option AllScope -Scope Global -Force
 Set-Alias -Name {{cmd}}i -Value __zoxide_zi -Option AllScope -Scope Global -Force
+Set-Alias -Name {{cmd}}c -Value __zoxide_zc -Option AllScope -Scope Global -Force
+Set-Alias -Name {{cmd}}ci -Value __zoxide_zci -Option AllScope -Scope Global -Force
 
 {%- when None %}
 

--- a/templates/tcsh.txt
+++ b/templates/tcsh.txt
@@ -51,6 +51,26 @@ alias __zoxide_zi 'set __zoxide_args = (\!*)\
 set __zoxide_pwd = `{{ pwd_cmd }}`\
 set __zoxide_result = "`zoxide query --exclude '"'"'$__zoxide_pwd'"'"' --interactive -- $__zoxide_args`" && cd "$__zoxide_result"'
 
+# Jump to a directory within the current directory.
+alias __zoxide_zc 'set __zoxide_args = (\!*)\
+if ("$#__zoxide_args" == 0) then\
+    cd ~\
+else\
+    if ("$#__zoxide_args" == 1 && "$__zoxide_args[1]" == "-") then\
+        cd -\
+    else if ("$#__zoxide_args" == 1 && -d "$__zoxide_args[1]") then\
+        cd "$__zoxide_args[1]"\
+    else\
+        set __zoxide_pwd = `{{ pwd_cmd }}`\
+        set __zoxide_result = "`zoxide query --exclude '"'"'$__zoxide_pwd'"'"' --base-dir '"'"'$__zoxide_pwd'"'"' -- $__zoxide_args`" && cd "$__zoxide_result"\
+    endif\
+endif'
+
+# Jump to a directory within the current directory using interactive search.
+alias __zoxide_zci 'set __zoxide_args = (\!*)\
+set __zoxide_pwd = `{{ pwd_cmd }}`\
+set __zoxide_result = "`zoxide query --exclude '"'"'$__zoxide_pwd'"'"' --interactive --base-dir '"'"'$__zoxide_pwd'"'"' -- $__zoxide_args`" && cd "$__zoxide_result"'
+
 {{ section }}
 # Commands for zoxide. Disable these using --no-cmd.
 #
@@ -60,6 +80,8 @@ set __zoxide_result = "`zoxide query --exclude '"'"'$__zoxide_pwd'"'"' --interac
 
 alias {{cmd}} __zoxide_z
 alias {{cmd}}i __zoxide_zi
+alias {{cmd}}c __zoxide_zc
+alias {{cmd}}ci __zoxide_zci
 
 {%- when None %}
 

--- a/templates/xonsh.txt
+++ b/templates/xonsh.txt
@@ -155,6 +155,51 @@ def __zoxide_zi(args: list[str]) -> None:
     __zoxide_cd(result)
 
 
+@__zoxide_errhandler
+def __zoxide_zc(args: list[str]) -> None:
+    """Jump to a directory within the current directory using only keywords."""
+    if args == []:
+        __zoxide_cd()
+    elif args == ["-"]:
+        __zoxide_cd("-")
+    elif len(args) == 1 and os.path.isdir(args[0]):
+        __zoxide_cd(args[0])
+    else:
+        base_dir = __zoxide_pwd()
+        try:
+            zoxide = __zoxide_bin()
+            cmd = subprocess.run(
+                [zoxide, "query", "--exclude", base_dir, "--base-dir", base_dir, "--"] + args,
+                check=True,
+                env=__zoxide_env(),
+                stdout=subprocess.PIPE,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise ZoxideSilentException() from exc
+
+        result = cmd.stdout[:-1]
+        __zoxide_cd(result)
+
+
+@__zoxide_errhandler
+def __zoxide_zci(args: list[str]) -> None:
+    """Jump to a directory within the current directory using interactive search."""
+    base_dir = __zoxide_pwd()
+    try:
+        zoxide = __zoxide_bin()
+        cmd = subprocess.run(
+            [zoxide, "query", "-i", "--base-dir", base_dir, "--"] + args,
+            check=True,
+            env=__zoxide_env(),
+            stdout=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise ZoxideSilentException() from exc
+
+    result = cmd.stdout[:-1]
+    __zoxide_cd(result)
+
+
 {{ section }}
 # Commands for zoxide. Disable these using --no-cmd.
 #
@@ -164,6 +209,8 @@ def __zoxide_zi(args: list[str]) -> None:
 
 builtins.aliases["{{cmd}}"] = __zoxide_z  # type: ignore  # pylint:disable=no-member
 builtins.aliases["{{cmd}}i"] = __zoxide_zi  # type: ignore  # pylint:disable=no-member
+builtins.aliases["{{cmd}}c"] = __zoxide_zc  # type: ignore  # pylint:disable=no-member
+builtins.aliases["{{cmd}}ci"] = __zoxide_zci  # type: ignore  # pylint:disable=no-member
 
 {%- when None %}
 

--- a/templates/xonsh.txt
+++ b/templates/xonsh.txt
@@ -169,7 +169,16 @@ def __zoxide_zc(args: list[str]) -> None:
         try:
             zoxide = __zoxide_bin()
             cmd = subprocess.run(
-                [zoxide, "query", "--exclude", base_dir, "--base-dir", base_dir, "--"] + args,
+                [
+                    zoxide,
+                    "query",
+                    "--exclude",
+                    base_dir,
+                    "--base-dir",
+                    base_dir,
+                    "--",
+                    *args,
+                ],
                 check=True,
                 env=__zoxide_env(),
                 stdout=subprocess.PIPE,
@@ -188,7 +197,7 @@ def __zoxide_zci(args: list[str]) -> None:
     try:
         zoxide = __zoxide_bin()
         cmd = subprocess.run(
-            [zoxide, "query", "-i", "--base-dir", base_dir, "--"] + args,
+            [zoxide, "query", "-i", "--base-dir", base_dir, "--", *args],
             check=True,
             env=__zoxide_env(),
             stdout=subprocess.PIPE,

--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -106,6 +106,27 @@ function __zoxide_zi() {
     result="$(\command zoxide query --interactive -- "$@")" && __zoxide_cd "${result}"
 }
 
+# Jump to a directory within the current directory.
+function __zoxide_zc() {
+    __zoxide_doctor
+    \builtin local base_dir
+    base_dir="$(__zoxide_pwd)"
+    \builtin local result
+    # shellcheck disable=SC2312
+    result="$(\command zoxide query --exclude "${base_dir}" --base-dir "${base_dir}" -- "$@")" &&
+        __zoxide_cd "${result}"
+}
+
+# Jump to a directory within the current directory using interactive search.
+function __zoxide_zci() {
+    __zoxide_doctor
+    \builtin local base_dir
+    base_dir="$(__zoxide_pwd)"
+    \builtin local result
+    result="$(\command zoxide query --interactive --base-dir "${base_dir}" -- "$@")" &&
+        __zoxide_cd "${result}"
+}
+
 {{ section }}
 # Commands for zoxide. Disable these using --no-cmd.
 #
@@ -119,6 +140,14 @@ function {{ cmd }}() {
 
 function {{ cmd }}i() {
     __zoxide_zi "$@"
+}
+
+function {{ cmd }}c() {
+    __zoxide_zc "$@"
+}
+
+function {{ cmd }}ci() {
+    __zoxide_zci "$@"
 }
 
 {%- when None %}


### PR DESCRIPTION
This PR adds shell shortcut (zc and zci) to jump to child directories (very similar to jc in autojump)
Uses --basedir option added in https://github.com/ajeetdsouza/zoxide/pull/1027
Addresses issue https://github.com/ajeetdsouza/zoxide/issues/1125