### PR TITLE
avoid-db-writes-sorting-by-score

### DIFF
--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -33,6 +33,7 @@ impl Run for Edit {
             }
             None => {
                 db.sort_by_score(now);
+                db.mark_dirty();
                 db.save()?;
                 Self::get_fzf()?.wait()?;
                 Ok(())

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -177,6 +177,9 @@ impl Database {
                 dir1.score(now).total_cmp(&dir2.score(now))
             })
         });
+    }
+
+    pub fn mark_dirty(&mut self) {
         self.with_dirty_mut(|dirty| *dirty = true);
     }
 


### PR DESCRIPTION
Currently, `sort_by_score` unconditionally marks the database as dirty, even if it just sorted the data (thus persisting does not change)

This causes z foo query calls to trigger a disk write even when no entries were added, removed, or lazily deleted. Since sort order is recomputed fresh on every open, there is nothing meaningful to persist in these cases.

## Changes
-Removed dirty-marking from `sort_by_score` in db/mod.rs
-Added an explicit `mark_dirty()` method to Database
-Updated cmd/edit.rs to call `mark_dirty()` before `save()`, since the edit workflow requires the sorted DB to be written to disk before launching fzf (the reload subprocess reads it back)

Basically, this just avoids unnecessary disk writes on every z query by not marking the DB dirty on sort.