### PR TITLE
Handle trailing semicolon + whitespace in PROMPT_COMMAND

### DIFF
--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -63,7 +63,7 @@ if [[ ${PROMPT_COMMAND:=} != *'__zoxide_hook'* ]]; then
         PROMPT_COMMAND=("${PROMPT_COMMAND[@]}" __zoxide_hook)
     else
         # shellcheck disable=SC2128,SC2178
-        PROMPT_COMMAND="${PROMPT_COMMAND%"${PROMPT_COMMAND##*[![:space:]]}"}"
+        PROMPT_COMMAND="${PROMPT_COMMAND%"${PROMPT_COMMAND##*[![:space:];]}"}"
         # shellcheck disable=SC2128,SC2178
         PROMPT_COMMAND="${PROMPT_COMMAND:+${PROMPT_COMMAND};}__zoxide_hook"
     fi


### PR DESCRIPTION
Fixes https://github.com/ajeetdsouza/zoxide/issues/1187.