### PR TITLE
ci: add riscv64 to release build matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
             deb: true
+          - os: ubuntu-24.04-riscv
+            target: riscv64gc-unknown-linux-gnu
+            deb: true
           - os: ubuntu-latest
             target: i686-unknown-linux-musl
             deb: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,11 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
             deb: true
-          - os: ubuntu-24.04-riscv
-            target: riscv64gc-unknown-linux-gnu
-            deb: true
           - os: ubuntu-latest
             target: i686-unknown-linux-musl
+            deb: true
+          - os: ubuntu-latest
+            target: riscv64gc-unknown-linux-musl
             deb: true
           - os: ubuntu-latest
             target: aarch64-linux-android


### PR DESCRIPTION
Adds riscv64gc-unknown-linux-gnu to the release matrix using native RISE riscv64 runners (ubuntu-24.04-riscv). Includes deb packaging. The install script already handles riscv64 detection but currently has no binary to download.

For personal accounts, install the RISE runners app on this repository: https://github.com/apps/rise-risc-v-runners-personal. Without it, the job stays queued with no runner.

Build validated: https://github.com/gounthar/zoxide/actions/runs/23428327604

Closes #1200