### PR TITLE
feat: new environment variable option `_ZO_FZF_OPTS_FILE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `$_ZO_FZF_OPTS_FILE` to specify configuration file for `fzf`
+
+### Added
+
 - POSIX: support for non-Cygwin Windows environments (e.g. Busybox).
 
 ### Fixed

--- a/man/man1/zoxide.1
+++ b/man/man1/zoxide.1
@@ -92,6 +92,10 @@ to use \fBzoxide-remove\fR(1) to remove any existing entries from the database.
 Custom options to pass to \fBfzf\fR(1) during interactive selection. See the
 manpage for the full list of options.
 .TP
+.B _ZO_FZF_OPTS_FILE
+Path to file containing custom options to pass to \fBfzf\fR(1) during interactive selection. See the
+manpage for the full list of options.
+.TP
 .B _ZO_MAXAGE
 Configures the aging algorithm, which limits the maximum number of entries in
 the database. By default, this is set to 10000.

--- a/man/man1/zoxide.1
+++ b/man/man1/zoxide.1
@@ -93,8 +93,8 @@ Custom options to pass to \fBfzf\fR(1) during interactive selection. See the
 manpage for the full list of options.
 .TP
 .B _ZO_FZF_OPTS_FILE
-Path to file containing custom options to pass to \fBfzf\fR(1) during interactive selection. See the
-manpage for the full list of options.
+Path to file containing custom options to pass to \fBfzf\fR(1) during
+interactive selection. See the manpage for the full list of options.
 .TP
 .B _ZO_MAXAGE
 Configures the aging algorithm, which limits the maximum number of entries in

--- a/src/cmd/cmd.rs
+++ b/src/cmd/cmd.rs
@@ -26,6 +26,7 @@ https://github.com/ajeetdsouza/zoxide
 {tab}<bold>_ZO_ECHO</bold>            {tab}Print the matched directory before navigating to it when set to 1
 {tab}<bold>_ZO_EXCLUDE_DIRS</bold>    {tab}List of directory globs to be excluded
 {tab}<bold>_ZO_FZF_OPTS</bold>        {tab}Custom flags to pass to fzf
+{tab}<bold>_ZO_FZF_OPTS_FILE</bold>   {tab}Path to file containing custom flags to pass to fzf
 {tab}<bold>_ZO_MAXAGE</bold>          {tab}Maximum total age after which entries start getting deleted
 {tab}<bold>_ZO_RESOLVE_SYMLINKS</bold>{tab}Resolve symlinks when storing paths").into_resettable()
     }

--- a/src/cmd/query.rs
+++ b/src/cmd/query.rs
@@ -92,6 +92,11 @@ impl Query {
 
     fn get_fzf() -> Result<FzfChild> {
         let mut fzf = Fzf::new()?;
+
+        if let Some(fzf_opts_file) = config::fzf_opts_file() {
+            fzf.env("FZF_DEFAULT_OPTS_FILE", fzf_opts_file);
+        }
+
         if let Some(fzf_opts) = config::fzf_opts() {
             fzf.env("FZF_DEFAULT_OPTS", fzf_opts)
         } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,11 @@ pub fn fzf_opts() -> Option<OsString> {
     env::var_os("_ZO_FZF_OPTS")
 }
 
+pub fn fzf_opts_file() -> Option<OsString> {
+    env::var_os("_ZO_FZF_OPTS_FILE")
+}
+
+
 pub fn maxage() -> Result<Rank> {
     env::var_os("_ZO_MAXAGE").map_or(Ok(10_000.0), |maxage| {
         let maxage = maxage.to_str().context("invalid unicode in _ZO_MAXAGE")?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,7 +51,6 @@ pub fn fzf_opts_file() -> Option<OsString> {
     env::var_os("_ZO_FZF_OPTS_FILE")
 }
 
-
 pub fn maxage() -> Result<Rank> {
     env::var_os("_ZO_MAXAGE").map_or(Ok(10_000.0), |maxage| {
         let maxage = maxage.to_str().context("invalid unicode in _ZO_MAXAGE")?;


### PR DESCRIPTION
This closes #1203.

## Summary
- `zoxide` will now recognize the environment variable `_ZO_FZF_OPTS_FILE`, in addition to `_ZO_FZF_OPTS`
- changed manpage and `--help` page accordingly
- updated `CHANGELOG.md` accordingly
- changes can be automatically merged, all 18 cargo tests pass

## Notes
Thanks for the amazing tool, `zoxide` changed my quality of life. This is a feature request made in #1203, I thought it made a lot of of sense and I have been wishing for the feature as well!

## Screenshot
<img width="1552" height="982" alt="image" src="https://github.com/user-attachments/assets/4c72ba5f-992d-434b-933c-5e14562ec7de" />
