### PR TITLE
feat: shorten /home/user to ~ in fzf

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -60,3 +60,7 @@ pub fn maxage() -> Result<Rank> {
 pub fn resolve_symlinks() -> bool {
     env::var_os("_ZO_RESOLVE_SYMLINKS").is_some_and(|var| var == "1")
 }
+
+pub fn get_home_dir() -> OsString {
+    env::var_os("HOME").unwrap_or("".into())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,5 +62,5 @@ pub fn resolve_symlinks() -> bool {
 }
 
 pub fn get_home_dir() -> OsString {
-    env::var_os("HOME").unwrap_or("".into())
+    env::var_os("HOME").unwrap_or_else(|| "".into())
 }

--- a/src/db/dir.rs
+++ b/src/db/dir.rs
@@ -3,6 +3,7 @@ use std::fmt::{self, Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
+use crate::config;
 use crate::util::{DAY, HOUR, WEEK};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -52,6 +53,27 @@ impl<'a> DirDisplay<'a> {
     pub fn with_separator(mut self, separator: char) -> Self {
         self.separator = separator;
         self
+    }
+
+    pub fn shorten_home_dir(&self) -> String {
+        let prefix = config::get_home_dir();
+        let prefix = prefix.to_str().expect("cannot convert $HOME to &str");
+        let path = if prefix.is_empty() {
+            self.dir.path.to_string()
+        } else {
+            match self.dir.path.as_ref().strip_prefix(prefix) {
+                Some(path) => format!("~{path}"),
+                None => self.dir.path.to_string(),
+            }
+        };
+
+        match self.now {
+            Some(now) => {
+                let score = self.dir.score(now).clamp(0.0, 9999.0);
+                format!("{score:>6.1}{}{path}", self.separator)
+            }
+            None => path,
+        }
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -163,7 +163,7 @@ fn expand_home_dir(path: &str) -> String {
         return path.to_string();
     }
 
-    match path.strip_prefix("~") {
+    match path.strip_prefix('~') {
         Some(path) => {
             format!("{}{}", home.to_str().expect("cannot convert OsString to &str"), path)
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -60,9 +60,9 @@ impl Fzf {
         self.args([
             // Non-POSIX args are only available on certain operating systems.
             if cfg!(target_os = "linux") {
-                r"--preview=\command -p ls -Cp --color=always --group-directories-first {2..}"
+                r#"--preview=sh -c 'dir=$1; case $dir in "~") dir=$HOME ;; "~/"*) dir=$HOME/${dir#"~/"} ;; esac; \command -p ls -Cp --color=always --group-directories-first -- "$dir"' sh {2..}"#
             } else {
-                r"--preview=\command -p ls -Cp {2..}"
+                r#"--preview=sh -c 'dir=$1; case $dir in "~") dir=$HOME ;; "~/"*) dir=$HOME/${dir#"~/"} ;; esac; \command -p ls -Cp -- "$dir"' sh {2..}"#
             },
             // Rounded edges don't display correctly on some terminals.
             "--preview-window=down,30%,sharp",
@@ -123,7 +123,11 @@ pub struct FzfChild(Child);
 impl FzfChild {
     pub fn write(&mut self, dir: &Dir, now: Epoch) -> Result<Option<String>> {
         let handle = self.0.stdin.as_mut().unwrap();
-        match write!(handle, "{}\0", dir.display().with_score(now).with_separator('\t')) {
+        match write!(
+            handle,
+            "{}\0",
+            dir.display().with_score(now).with_separator('\t').shorten_home_dir()
+        ) {
             Ok(()) => Ok(None),
             Err(e) if e.kind() == io::ErrorKind::BrokenPipe => self.wait().map(Some),
             Err(e) => Err(e).context("could not write to fzf"),
@@ -140,13 +144,30 @@ impl FzfChild {
 
         let status = self.0.wait().context("wait failed on fzf")?;
         match status.code() {
-            Some(0) => Ok(output),
+            Some(0) => Ok(match output.split_once('\t') {
+                Some((score, path)) => format!("{score}\t{}", expand_home_dir(path)),
+                None => expand_home_dir(&output),
+            }),
             Some(1) => bail!("no match found"),
             Some(2) => bail!("fzf returned an error"),
             Some(130) => bail!(SilentExit { code: 130 }),
             Some(128..=254) | None => bail!("fzf was terminated"),
             _ => bail!("fzf returned an unknown error"),
         }
+    }
+}
+
+fn expand_home_dir(path: &str) -> String {
+    let home = crate::config::get_home_dir();
+    if home.is_empty() {
+        return path.to_string();
+    }
+
+    match path.strip_prefix("~") {
+        Some(path) => {
+            format!("{}{}", home.to_str().expect("cannot convert OsString to &str"), path)
+        }
+        None => path.to_string(),
     }
 }
 


### PR DESCRIPTION
This closes #1162.

## Before
Using fzf in zoxide (through `zi` or `zoxide query -i`) listed all directories as `/home/user/...` or `/Users/user/...`.

## After
The fuzzy finder shortens the prefix to `~`. Other features remain intact & functional as before.
<img width="1552" height="982" alt="image" src="https://github.com/user-attachments/assets/61b28989-9c55-4951-9234-fe486e470285" />

## Notes
This commit impacts just the fzf component, used in `zi`. The fuzzy finder will no longer display absolute paths as /home/user or /Users/user (macOS). These prefixes will be shortened to '~'. This affects just fzf visuals; that is, the final output of fzf still displays the full absolute path. `ls` preview within fzf and final `zi` command all work as expected. Works correctly on macOS & Linux.

This is arguably a big UI change, I totally understand if the devs are reluctant to merge this.