### PR TITLE
fix: normalize path separators for keyword matching on Windows

### DIFF
--- a/src/db/stream.rs
+++ b/src/db/stream.rs
@@ -205,10 +205,19 @@ mod tests {
     #[case(&["foo", "o", "bar"], "/foo/bar", false)]
     #[case(&["/foo/", "/bar"], "/foo/bar", false)]
     #[case(&["/foo/", "/bar"], "/foo/baz/bar", true)]
+    fn query(#[case] keywords: &[&str], #[case] path: &str, #[case] is_match: bool) {
+        let db = &mut Database::new(PathBuf::new(), Vec::new(), |_| Vec::new(), false);
+        let options = StreamOptions::new(0).with_keywords(keywords.iter());
+        let stream = Stream::new(db, options);
+        assert_eq!(is_match, stream.filter_by_keywords(path));
+    }
+
     // Forward slash matching on Windows-style paths
+    #[cfg(windows)]
+    #[rstest]
     #[case(&["bar/meow"], r"~\foo\bar\meow", true)]
     #[case(&["bar", "meow"], r"~\foo\bar\meow", true)]
-    fn query(#[case] keywords: &[&str], #[case] path: &str, #[case] is_match: bool) {
+    fn query_windows(#[case] keywords: &[&str], #[case] path: &str, #[case] is_match: bool) {
         let db = &mut Database::new(PathBuf::new(), Vec::new(), |_| Vec::new(), false);
         let options = StreamOptions::new(0).with_keywords(keywords.iter());
         let stream = Stream::new(db, options);

--- a/src/db/stream.rs
+++ b/src/db/stream.rs
@@ -83,7 +83,10 @@ impl<'a> Stream<'a> {
             None => return true,
         };
 
-        let path = util::to_lowercase(path);
+        let mut path = util::to_lowercase(path);
+        if cfg!(windows) {
+            path = path.replace('\\', "/");
+        }
         let mut path = path.as_str();
         match path.rfind(keywords_last) {
             Some(idx) => {
@@ -202,6 +205,9 @@ mod tests {
     #[case(&["foo", "o", "bar"], "/foo/bar", false)]
     #[case(&["/foo/", "/bar"], "/foo/bar", false)]
     #[case(&["/foo/", "/bar"], "/foo/baz/bar", true)]
+    // Forward slash matching on Windows-style paths
+    #[case(&["bar/meow"], r"~\foo\bar\meow", true)]
+    #[case(&["bar", "meow"], r"~\foo\bar\meow", true)]
     fn query(#[case] keywords: &[&str], #[case] path: &str, #[case] is_match: bool) {
         let db = &mut Database::new(PathBuf::new(), Vec::new(), |_| Vec::new(), false);
         let options = StreamOptions::new(0).with_keywords(keywords.iter());


### PR DESCRIPTION
## Summary

Normalizes backslash path separators to forward slashes when matching keywords on Windows, so that queries like `cd bar/meow` correctly match stored paths like `~\foo\bar\meow`.

On Windows, the database stores paths with backslashes (`\`), but users may type queries with forward slashes (`/`). The `filter_by_keywords` function now converts backslashes to forward slashes before matching, ensuring both separator styles work.

Added test cases for Windows-style path matching with forward-slash queries.

Closes #1217