### PR TITLE
Fix: Add explicit . and .. cases in templates 

### DIFF
--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -111,8 +111,6 @@ function __zoxide_z() {
         __zoxide_cd ~
     elif [[ $# -eq 1 && $1 == '-' ]]; then
         __zoxide_cd "${OLDPWD}"
-    elif [[ $# -eq 1 && $1 == '~' ]]; then
-        __zoxide_cd ~
     elif [[ $# -eq 1 && ($1 == '.' || $1 == '..') ]]; then
         __zoxide_cd "$1"
     elif [[ $# -eq 1 && -d $1 ]]; then

--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -111,6 +111,10 @@ function __zoxide_z() {
         __zoxide_cd ~
     elif [[ $# -eq 1 && $1 == '-' ]]; then
         __zoxide_cd "${OLDPWD}"
+    elif [[ $# -eq 1 && $1 == '~' ]]; then
+        __zoxide_cd ~
+    elif [[ $# -eq 1 && ($1 == '.' || $1 == '..') ]]; then
+        __zoxide_cd "$1"
     elif [[ $# -eq 1 && -d $1 ]]; then
         __zoxide_cd "$1"
     elif [[ $# -eq 2 && $1 == '--' ]]; then

--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -79,6 +79,8 @@ function __zoxide_z
         __zoxide_cd $HOME
     else if test "$argv" = -
         __zoxide_cd -
+    else if test $argc -eq 1 -a \( "$argv[1]" = '.' -o "$argv[1]" = '..' \)
+        __zoxide_cd $argv[1]
     else if test $argc -eq 1 -a -d $argv[1]
         __zoxide_cd $argv[1]
     else if test $argc -eq 2 -a $argv[1] = --

--- a/templates/posix.txt
+++ b/templates/posix.txt
@@ -105,6 +105,8 @@ __zoxide_z() {
             \command printf 'zoxide: $OLDPWD is not set'
             return 1
         fi
+    elif [ "$#" -eq 1 ] && [ "$1" = '.' -o "$1" = '..' ]; then
+        __zoxide_cd "$1"
     elif [ "$#" -eq 1 ] && [ -d "$1" ]; then
         __zoxide_cd "$1"
     else

--- a/templates/posix.txt
+++ b/templates/posix.txt
@@ -105,7 +105,7 @@ __zoxide_z() {
             \command printf 'zoxide: $OLDPWD is not set'
             return 1
         fi
-    elif [ "$#" -eq 1 ] && [ "$1" = '.' -o "$1" = '..' ]; then
+    elif [ "$#" -eq 1 ] && { [ "$1" = '.' ] || [ "$1" = '..' ]; }; then
         __zoxide_cd "$1"
     elif [ "$#" -eq 1 ] && [ -d "$1" ]; then
         __zoxide_cd "$1"

--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -88,6 +88,8 @@ function __zoxide_z() {
     __zoxide_doctor
     if [[ "$#" -eq 0 ]]; then
         __zoxide_cd ~
+    elif [[ "$#" -eq 1 && ($1 == '.' || $1 == '..') ]]; then
+        __zoxide_cd "$1"
     elif [[ "$#" -eq 1 ]] && { [[ -d "$1" ]] || [[ "$1" = '-' ]] || [[ "$1" =~ ^[-+][0-9]+$ ]]; }; then
         __zoxide_cd "$1"
     elif [[ "$#" -eq 2 ]] && [[ "$1" = "--" ]]; then


### PR DESCRIPTION
# Summary
- Fix issue #1155 

## Changes
Added explicit . and .. cases in templates (for zsh, bash, posix, ...) to allow z . and z .. commands to work, helping aliases work better. Hope it's helpful!