### PR TITLE
Remove nix dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -168,12 +168,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e962dae2b1e5007fe9e3db363ddc43a8bf25546d279f7a8a4401204690e80c"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
 dependencies = [
  "clap",
 ]
@@ -470,18 +464,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "nix"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
 
 [[package]]
 name = "nom"
@@ -1185,7 +1167,6 @@ dependencies = [
  "dunce",
  "fastrand",
  "glob",
- "nix",
  "ouroboros",
  "rstest",
  "rstest_reuse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,12 +32,6 @@ ouroboros = "0.18.3"
 serde = { version = "1.0.116", features = ["derive"] }
 time = { version = "0.3.47", default-features = false, features = ["parsing", "macros", "std"] }
 
-[target.'cfg(unix)'.dependencies]
-nix = { version = "0.31.2", default-features = false, features = [
-    "fs",
-    "user",
-] }
-
 [target.'cfg(windows)'.dependencies]
 which = "8.0.2"
 

--- a/src/import.rs
+++ b/src/import.rs
@@ -48,7 +48,7 @@ pub(crate) struct ImportError {
 /// format. Doesn't abort on per-record errors — bad rows are skipped, the
 /// rest of the import continues. After the iteration completes successfully,
 /// the database is deduplicated and aged.
-pub(crate) fn run<I: Importer>(importer: &I, db: &mut Database) -> Result<()> {
+pub(crate) fn run(importer: &impl Importer, db: &mut Database) -> Result<()> {
     let stderr = io::stderr();
     let mut stderr = stderr.lock();
 
@@ -60,7 +60,7 @@ pub(crate) fn run<I: Importer>(importer: &I, db: &mut Database) -> Result<()> {
                     Some(path) => format!("{}:{}", path.display(), e.line_num),
                     None => format!("line {}", e.line_num),
                 };
-                let _ = writeln!(stderr, "{location}: {:#}", e.source);
+                _ = writeln!(stderr, "{location}: {:#}", e.source);
             }
         }
     }

--- a/src/import/atuin.rs
+++ b/src/import/atuin.rs
@@ -110,7 +110,7 @@ impl Iterator for Iter {
 
 impl Drop for Iter {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        _ = self.child.kill();
+        _ = self.child.wait();
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -168,13 +168,9 @@ pub fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> Result<()> {
         // Set the owner of the tmpfile (UNIX only).
         #[cfg(unix)]
         if let Ok(metadata) = path.metadata() {
-            use std::os::unix::fs::MetadataExt;
+            use std::os::unix::fs::{MetadataExt, fchown};
 
-            use nix::unistd::{self, Gid, Uid};
-
-            let uid = Uid::from_raw(metadata.uid());
-            let gid = Gid::from_raw(metadata.gid());
-            _ = unistd::fchown(&tmp_file, Some(uid), Some(gid));
+            _ = fchown(&tmp_file, Some(metadata.uid()), Some(metadata.gid()));
         }
 
         // Close and rename the tmpfile.


### PR DESCRIPTION
The specific feature we needed from the `nix` crate is now part of the Rust stdlib.
