### PR TITLE
fix: skip zsh doctor in non-interactive shells

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -33,22 +33,6 @@ make_template!(Tcsh, "tcsh.txt");
 make_template!(Xonsh, "xonsh.txt");
 make_template!(Zsh, "zsh.txt");
 
-#[cfg(test)]
-mod render_tests {
-    use askama::Template;
-
-    use super::*;
-
-    #[test]
-    fn zsh_doctor_skips_non_interactive_shells() {
-        let opts =
-            Opts { cmd: Some("z"), hook: InitHook::Prompt, echo: false, resolve_symlinks: false };
-        let source = Zsh(&opts).render().unwrap();
-
-        assert!(source.contains("[[ $- == *i* ]] || return 0"));
-    }
-}
-
 #[cfg(feature = "nix-dev")]
 #[cfg(test)]
 mod tests {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -33,6 +33,22 @@ make_template!(Tcsh, "tcsh.txt");
 make_template!(Xonsh, "xonsh.txt");
 make_template!(Zsh, "zsh.txt");
 
+#[cfg(test)]
+mod render_tests {
+    use askama::Template;
+
+    use super::*;
+
+    #[test]
+    fn zsh_doctor_skips_non_interactive_shells() {
+        let opts =
+            Opts { cmd: Some("z"), hook: InitHook::Prompt, echo: false, resolve_symlinks: false };
+        let source = Zsh(&opts).render().unwrap();
+
+        assert!(source.contains("[[ $- == *i* ]] || return 0"));
+    }
+}
+
 #[cfg(feature = "nix-dev")]
 #[cfg(test)]
 mod tests {

--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -59,6 +59,7 @@ function __zoxide_doctor() {
 
 {%- else %}
     [[ ${_ZO_DOCTOR:-1} -ne 0 ]] || return 0
+    [[ $- == *i* ]] || return 0
 
 {%- if hook == InitHook::Prompt %}
     [[ ${precmd_functions[(Ie)__zoxide_hook]:-} -eq 0 ]] || return 0


### PR DESCRIPTION
Fixes #1208.

## Summary
- make the generated zsh doctor check return early when the shell is non-interactive
- keep hook setup and interactive doctor behavior unchanged
- add a render regression test for the generated zsh guard

## Tests
- `CARGO_HOME=$PWD/.cargo-home CARGO_TARGET_DIR=$PWD/target cargo test shell::render_tests::zsh_doctor_skips_non_interactive_shells`
- `CARGO_HOME=$PWD/.cargo-home CARGO_TARGET_DIR=$PWD/target cargo test --workspace`
- `CARGO_HOME=$PWD/.cargo-home CARGO_TARGET_DIR=$PWD/target cargo fmt --all --check`
- `CARGO_HOME=$PWD/.cargo-home CARGO_TARGET_DIR=$PWD/target cargo test --features nix-dev shell::tests::zsh_zsh`
- `git diff --check`