### PR TITLE
Accept existing paths in interactive query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `zoxide query --interactive` now accepts a single existing path directly.
 - PowerShell: use fully qualified names when invoking cmdlets.
 - Bash/Fish/POSIX/Zsh: resolve symlinks on Windows.
 

--- a/src/cmd/query.rs
+++ b/src/cmd/query.rs
@@ -1,4 +1,5 @@
 use std::io::{self, Write};
+use std::path::Path;
 
 use anyhow::{Context, Result};
 
@@ -18,15 +19,48 @@ impl Run for Query {
 impl Query {
     fn query(&self, db: &mut Database) -> Result<()> {
         let now = util::current_time()?;
-        let mut stream = self.get_stream(db, now)?;
 
         if self.interactive {
+            if let Some(path) = self.existing_path()? {
+                println!("{path}");
+                return Ok(());
+            }
+
+            let mut stream = self.get_stream(db, now)?;
             self.query_interactive(&mut stream, now)
         } else if self.list {
+            let mut stream = self.get_stream(db, now)?;
             self.query_list(&mut stream, now)
         } else {
+            let mut stream = self.get_stream(db, now)?;
             self.query_first(&mut stream, now)
         }
+    }
+
+    fn existing_path(&self) -> Result<Option<String>> {
+        if self.score || self.keywords.len() != 1 {
+            return Ok(None);
+        }
+
+        let path = Path::new(&self.keywords[0]);
+        if !path.is_dir() {
+            return Ok(None);
+        }
+
+        let path = util::resolve_path(path)?;
+        let path = util::path_to_str(&path)?;
+
+        if Some(path) == self.exclude.as_deref() {
+            return Ok(None);
+        }
+
+        if let Some(base_dir) = &self.base_dir
+            && !Path::new(path).starts_with(base_dir)
+        {
+            return Ok(None);
+        }
+
+        Ok(Some(path.to_owned()))
     }
 
     fn query_interactive(&self, stream: &mut Stream, now: Epoch) -> Result<()> {

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -1,0 +1,20 @@
+use assert_cmd::Command;
+
+#[test]
+fn interactive_query_accepts_existing_path() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let target_parent = tempfile::tempdir().unwrap();
+    let target = target_parent.path().join("project");
+    std::fs::create_dir(&target).unwrap();
+
+    let expected = target.to_string_lossy();
+
+    Command::cargo_bin("zoxide")
+        .unwrap()
+        .env("_ZO_DATA_DIR", data_dir.path())
+        .args(["query", "--interactive", "--", expected.as_ref()])
+        .assert()
+        .success()
+        .stdout(format!("{expected}\n"))
+        .stderr("");
+}

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -5,7 +5,7 @@ fn interactive_query_accepts_existing_path() {
     let data_dir = tempfile::tempdir().unwrap();
     let target_parent = tempfile::tempdir().unwrap();
     let target = target_parent.path().join("project");
-    std::fs::create_dir(&target).unwrap();
+    std::fs::create_dir_all(&target).unwrap();
 
     let expected = target.to_string_lossy();
 


### PR DESCRIPTION
Closes #1239.

This updates `zoxide query --interactive` to return a single existing directory path directly before launching fzf. That makes `zi <real path>` behave like a direct jump while keeping the normal fzf flow for non-path queries, multiple keywords, and score output.

I also added an integration test for the direct existing-path case.

Tested:
- `cargo fmt --all -- --check`
- `cargo test --test query --no-default-features`
- `cargo test db::stream::tests::query --no-default-features`
- `cargo test --workspace --no-default-features --no-fail-fast`
- `cargo clippy --all-features --all-targets -- -Dwarnings`
- `git diff --check`