### PR TITLE
docs: add PowerShell prompt compatibility note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,12 @@ zoxide can be installed in 4 easy steps:
    > ```powershell
    > Invoke-Expression (& { (zoxide init powershell | Out-String) })
    > ```
+   >
+   > **Note for PowerShell users:** If you use a prompt theme tool (such as
+   > oh-my-posh, starship, or posh-git), make sure zoxide is initialized
+   > **after** it in your profile. This is because zoxide wraps the existing
+   > `prompt` function to record directories. This is not a concern on other
+   > shells like Bash or Zsh.
 
    </details>
 

--- a/README.md
+++ b/README.md
@@ -281,6 +281,12 @@ zoxide can be installed in 4 easy steps:
    > ```powershell
    > Invoke-Expression (& { (zoxide init powershell | Out-String) })
    > ```
+   >
+   > **Note for PowerShell users:** If you use a prompt theme tool (such as
+   > oh-my-posh, starship, or posh-git), make sure zoxide is initialized
+   > **after** it in your profile. This is because zoxide wraps the existing
+   > `prompt` function to record directories. This is not a concern on other
+   > shells like Bash or Zsh.
 
    </details>
 


### PR DESCRIPTION
Add a note to the PowerShell installation section explaining that zoxide must be initialized after prompt theme tools (e.g. oh-my-posh, starship, posh-git) in the user profile.

This limitation is unique to PowerShell because it uses a single `prompt` function that gets overwritten by the last initialization. Other shells like Bash and Zsh use array-based hook mechanisms (`PROMPT_COMMAND` / `precmd_functions`) and are not affected.

Closes: https://github.com/ajeetdsouza/zoxide/issues/74, https://github.com/ajeetdsouza/zoxide/issues/877, https://github.com/ajeetdsouza/zoxide/issues/1021