### PR TITLE
Fix MSYS2 cygpath pwd substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Bash/Zsh: fix `z` failing on Cygwin/MSYS2 due to `cygpath` being passed a bad string.
+
 ## [0.10.0] - 2026-07-04
 
 ### Added

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -33,6 +33,26 @@ make_template!(Tcsh, "tcsh.txt");
 make_template!(Xonsh, "xonsh.txt");
 make_template!(Zsh, "zsh.txt");
 
+#[cfg(test)]
+mod template_tests {
+    #[test]
+    fn windows_bash_and_zsh_pwd_substitute_before_cygpath() {
+        for (name, template) in [
+            ("bash", include_str!("../templates/bash.txt")),
+            ("zsh", include_str!("../templates/zsh.txt")),
+        ] {
+            assert!(
+                template.contains(r#"\command cygpath -w "$({{ pwd }})""#),
+                "{name} template should pass the output of pwd to cygpath"
+            );
+            assert!(
+                !template.contains(r#"\command cygpath -w "{{ pwd }}""#),
+                "{name} template should not pass the literal pwd command to cygpath"
+            );
+        }
+    }
+}
+
 #[cfg(feature = "nix-dev")]
 #[cfg(test)]
 mod tests {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -33,26 +33,6 @@ make_template!(Tcsh, "tcsh.txt");
 make_template!(Xonsh, "xonsh.txt");
 make_template!(Zsh, "zsh.txt");
 
-#[cfg(test)]
-mod template_tests {
-    #[test]
-    fn windows_bash_and_zsh_pwd_substitute_before_cygpath() {
-        for (name, template) in [
-            ("bash", include_str!("../templates/bash.txt")),
-            ("zsh", include_str!("../templates/zsh.txt")),
-        ] {
-            assert!(
-                template.contains(r#"\command cygpath -w "$({{ pwd }})""#),
-                "{name} template should pass the output of pwd to cygpath"
-            );
-            assert!(
-                !template.contains(r#"\command cygpath -w "{{ pwd }}""#),
-                "{name} template should not pass the literal pwd command to cygpath"
-            );
-        }
-    }
-}
-
 #[cfg(feature = "nix-dev")]
 #[cfg(test)]
 mod tests {

--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -16,7 +16,7 @@ function __zoxide_pwd() {
 {%- let pwd = "\\builtin pwd -L" -%}
 {%- endif -%}
 {%- if cfg!(windows) %}
-    \command cygpath -w "{{ pwd }}"
+    \command cygpath -w "$({{ pwd }})"
 {%- else %}
     {{ pwd }}
 {%- endif %}

--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -16,7 +16,7 @@ function __zoxide_pwd() {
 {%- let pwd = "\\builtin pwd -L" -%}
 {%- endif -%}
 {%- if cfg!(windows) %}
-    \command cygpath -w "{{ pwd }}"
+    \command cygpath -w "$({{ pwd }})"
 {%- else %}
     {{ pwd }}
 {%- endif %}


### PR DESCRIPTION
## Summary
- Pass the result of `pwd` to `cygpath` in Windows Bash/Zsh init snippets instead of passing the literal command string.
- Add a focused regression test for the Bash/Zsh template lines.

Fixes #1259

## Tests
- `cargo test windows_bash_and_zsh_pwd_substitute_before_cygpath`
- `cargo test`
- `cargo test --features nix-dev bash_bash`
- `cargo test --features nix-dev zsh_zsh`
- `cargo test --features nix-dev bash_shellcheck`
- `cargo test --features nix-dev zsh_shellcheck`
- `cargo fmt --check`
- `cargo clippy --all-features --all-targets -- -Dwarnings`
- `git diff --check`
- `cargo check --target x86_64-pc-windows-gnu`
