### PR TITLE
fix: reject non-finite ranks when importing

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -121,6 +121,14 @@ impl Database {
     pub fn age(&mut self, max_age: Rank) {
         let mut dirty = false;
         self.with_dirs_mut(|dirs| {
+            // A non-finite rank would make the total non-finite too, which
+            // either scales every other rank to zero and drops it, or leaves
+            // the total NaN so that no comparison below ever holds and the
+            // database stops ageing entirely. Drop those entries instead.
+            let len_before = dirs.len();
+            dirs.retain(|dir| dir.rank.is_finite());
+            dirty |= dirs.len() != len_before;
+
             let total_age = dirs.iter().map(|dir| dir.rank).sum::<Rank>();
             if total_age > max_age {
                 let factor = 0.9 * max_age / total_age;
@@ -284,5 +292,42 @@ mod tests {
             assert!(!db.remove(path));
             db.save().unwrap();
         }
+    }
+
+    #[test]
+    fn age_drops_non_finite_ranks() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let now = 946684800;
+
+        let mut db = Database::open_dir(data_dir.path()).unwrap();
+        db.add_unchecked("/foo", 1.0, now);
+        db.add_unchecked("/bar", f64::INFINITY, now);
+        db.add_unchecked("/baz", f64::NAN, now);
+        db.age(10000.0);
+
+        // The finite entry survives, and it is not scaled to zero by a total
+        // that a non-finite rank has poisoned.
+        let dirs = db.dirs();
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0].path, "/foo");
+        assert!((dirs[0].rank - 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn age_keeps_ageing_after_non_finite_rank() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let now = 946684800;
+
+        let mut db = Database::open_dir(data_dir.path()).unwrap();
+        db.add_unchecked("/poison", f64::NAN, now);
+        for i in 0..20 {
+            db.add_unchecked(format!("/dir{i}"), 600.0, now);
+        }
+        db.age(10000.0);
+
+        // Without dropping the NaN the total stays NaN, no comparison holds,
+        // and the database never ages below max_age again.
+        let total = db.dirs().iter().map(|dir| dir.rank).sum::<Rank>();
+        assert!(total <= 10000.0, "database did not age: total is {total}");
     }
 }

--- a/src/import/z.rs
+++ b/src/import/z.rs
@@ -50,7 +50,14 @@ impl<R: BufRead> Iter<R> {
         let last_accessed = last_accessed.parse::<u64>().map_err(|_| err())?;
 
         let rank = split.next().ok_or_else(err)?;
-        let rank = rank.parse::<f64>().map_err(|_| err())?;
+        // `parse` accepts `inf` / `nan`, and anything past f64's range parses
+        // as infinity. Aging multiplies every rank by a factor derived from
+        // their total, so letting one through turns the entire database into
+        // zeroes and NaNs.
+        let rank = match rank.parse::<f64>() {
+            Ok(rank) if rank.is_finite() => rank,
+            _ => return Err(err()),
+        };
 
         let path = split.next().ok_or_else(err)?;
 
@@ -99,5 +106,29 @@ fn data_path() -> Result<PathBuf> {
             path.push(".z");
             Ok(path)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case("/foo|3|100", true)]
+    #[case("/foo|0|100", true)]
+    #[case("/foo|1.5|100", true)]
+    // A path may contain `|`.
+    #[case("/f|oo|3|100", true)]
+    // Non-finite ranks poison the total that ageing divides by.
+    #[case("/foo|inf|100", false)]
+    #[case("/foo|-inf|100", false)]
+    #[case("/foo|nan|100", false)]
+    // Beyond f64's range, which `parse` rounds to infinity.
+    #[case("/foo|1e400|100", false)]
+    fn parse_line_rank(#[case] line: &str, #[case] is_ok: bool) {
+        let iter = Iter::new(std::io::empty(), PathBuf::new());
+        assert_eq!(is_ok, iter.parse_line(line.as_bytes()).is_ok());
     }
 }


### PR DESCRIPTION
Importing a data file whose rank is `inf`, `nan`, or just larger than an
`f64` can hold throws away the rest of the database:

```console
$ cat ~/.z
/aaa|5|1000000000
/bbb|inf|1000000000
/ccc|3|1000000000
/ddd|10|1000000000

$ zoxide import z; echo "exit $?"
exit 0

$ zoxide query --list --score --all
   NaN /bbb
```

Three directories are gone and the command reports success.

`Database::age` scales every rank by `0.9 * max_age / total`. One non-finite
rank makes `total` infinite, so the factor is `0.0`: every other directory is
multiplied down to `0.0`, drops below the `1.0` threshold and is removed,
while the entry responsible survives, because `NaN < 1.0` is false like every
other comparison against it.

It does not stop there. The NaN keeps the total NaN, so `total_age > max_age`
is never true again and the database stops ageing permanently — 20 dirs at
rank 600 stay at a total of 12000 instead of being scaled back to 9000.

`last_accessed` is already validated, in that `parse::<u64>()` rejects
anything unreasonable and reports it with a line number. Doing the same for
the rank keeps the bad line out and leaves the rest of the file alone:

```console
$ zoxide import z
/home/user/.z:2: invalid entry: /bbb|inf|1000000000

$ zoxide query --list --score --all
   1.2 /aaa
   0.8 /ccc
```

`age` drops non-finite ranks too, so a database that has already been hit by
this recovers on the next run rather than staying stuck.

This covers `z`, `fasd`, `z.lua` and `zsh-z`, which share the parser.
`autojump` passes its rank through a sigmoid and was never affected.

#### Testing

`cargo test` (26 tests), `cargo +nightly fmt --check` and
`cargo clippy --all-targets -- -D warnings` are clean.

Added a parametrised parser test covering `inf`, `-inf`, `nan` and `1e400`
alongside the ranks that must keep working, including a path containing `|`,
and two `age` tests: one that the finite entries survive a poisoned database,
one that ageing still brings the total back under `max_age`. Reverting either
half of the fix on its own fails its tests and leaves the valid cases green.
