### PR TITLE
fix: match forward slashes in queries on Windows

### DIFF
--- a/src/db/stream.rs
+++ b/src/db/stream.rs
@@ -83,7 +83,7 @@ impl<'a> Stream<'a> {
             None => return true,
         };
 
-        let path = util::to_lowercase(path);
+        let path = util::normalize_separators(util::to_lowercase(path));
         let mut path = path.as_str();
         match path.rfind(keywords_last) {
             Some(idx) => {
@@ -149,7 +149,10 @@ impl StreamOptions {
         I: IntoIterator,
         I::Item: AsRef<str>,
     {
-        self.keywords = keywords.into_iter().map(util::to_lowercase).collect();
+        self.keywords = keywords
+            .into_iter()
+            .map(|keyword| util::normalize_separators(util::to_lowercase(keyword)))
+            .collect();
         self
     }
 
@@ -203,6 +206,22 @@ mod tests {
     #[case(&["/foo/", "/bar"], "/foo/bar", false)]
     #[case(&["/foo/", "/bar"], "/foo/baz/bar", true)]
     fn query(#[case] keywords: &[&str], #[case] path: &str, #[case] is_match: bool) {
+        let db = &mut Database::new(PathBuf::new(), Vec::new(), |_| Vec::new(), false);
+        let options = StreamOptions::new(0).with_keywords(keywords.iter());
+        let stream = Stream::new(db, options);
+        assert_eq!(is_match, stream.filter_by_keywords(path));
+    }
+
+    #[cfg(windows)]
+    #[rstest]
+    // Forward slashes in the query match backslashes in the database
+    #[case(&["bar/meow"], r"c:\users\alice\foo\bar\meow", true)]
+    #[case(&["foo/bar"], r"c:\users\alice\foo\bar\meow", false)]
+    // ...and vice versa
+    #[case(&[r"bar\meow"], "c:/users/alice/foo/bar/meow", true)]
+    // Mixed separators
+    #[case(&["foo/bar", r"\meow"], r"c:\users\alice\foo\bar\meow", true)]
+    fn query_separators(#[case] keywords: &[&str], #[case] path: &str, #[case] is_match: bool) {
         let db = &mut Database::new(PathBuf::new(), Vec::new(), |_| Vec::new(), false);
         let options = StreamOptions::new(0).with_keywords(keywords.iter());
         let stream = Stream::new(db, options);

--- a/src/util.rs
+++ b/src/util.rs
@@ -378,3 +378,16 @@ pub fn to_lowercase(s: impl AsRef<str>) -> String {
     let s = s.as_ref();
     if s.is_ascii() { s.to_ascii_lowercase() } else { s.to_lowercase() }
 }
+
+/// Rewrite path separators to a single canonical form, so that queries match
+/// regardless of which separator was typed.
+///
+/// On Windows both `/` and `\` are accepted by the OS, so they are treated as
+/// equivalent. Elsewhere `\` is a valid filename character and is left alone.
+pub fn normalize_separators(s: String) -> String {
+    #[cfg(windows)]
+    if s.contains('/') {
+        return s.replace('/', "\\");
+    }
+    s
+}


### PR DESCRIPTION
Closes #1217.

## Problem

On Windows, both `/` and `\` are valid path separators, but zoxide only matched database paths against the separator the user typed. With `C:\Users\Alice\foo\bar\meow` in the database and the shell sitting at `C:\Users\Alice`:

- `z bar\meow` matches
- `z bar/meow` does not

## Fix

Canonicalize separators before matching, on both sides of the comparison — the query keywords (`StreamOptions::with_keywords`) and the database path (`Stream::filter_by_keywords`). Normalizing the path as well as the query means an entry stored with forward slashes is also reachable by a backslash query.

The normalization is a no-op off Windows, where `\` is a legal filename character and rewriting it would be wrong. `path::is_separator` in `filter_by_keywords` already treats both characters as separators on Windows, so the "keyword must match the last component" check keeps working with either form.

## Tests

Added a `#[cfg(windows)]` `query_separators` case set to `src/db/stream.rs` covering forward-slash queries against backslash paths, the reverse, mixed separators, and the negative case where the match is not the last component.

## Verification

Run on macOS against a `git stash` baseline; both trees are identical apart from the new Windows-only cases:

```
cargo test                                  16 passed, 0 failed
cargo fmt --check                           clean (exit 0)
cargo clippy --all-targets -- -D warnings   clean
```

**Honest limitation:** I do not have a Windows machine, and `rustup` is not available here to add the `x86_64-pc-windows-msvc` target, so I could not compile or run the `cfg(windows)` paths natively. To validate them I temporarily flipped the two new `cfg(windows)` gates to `cfg(unix)` *and* substituted `path::is_separator` with a closure accepting both `/` and `\` (to mimic Windows' `is_separator`), then ran the suite: **20 passed, 0 failed**, including all 4 new cases and the pre-existing ones. Those temporary edits were reverted before committing — the diff contains only the real change. CI on `windows-latest` should give the genuine confirmation.

---

*Disclosure: this patch was prepared with AI assistance (Claude). I reviewed the change and ran the verification commands above myself.*
