### PR TITLE
add support for schemesh

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,17 @@ zoxide can be installed in 4 easy steps:
    </details>
 
    <details>
+   <summary>Schemesh</summary>
+
+   > Add this to the <ins>**end**</ins> of your config file (usually `~/.config/schemesh/repl_init.ss`):
+   >
+   > ```scheme
+   > (sh-eval-string (sh-run/string {zoxide init schemesh}) 'scheme)
+   > ```
+
+   </details>
+
+   <details>
    <summary>Tcsh</summary>
 
    > Add this to the <ins>**end**</ins> of your config file (usually `~/.tcshrc`):

--- a/contrib/completions/_zoxide
+++ b/contrib/completions/_zoxide
@@ -178,7 +178,7 @@ _arguments "${_arguments_options[@]}" : \
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-':shell:(bash elvish fish nushell posix powershell tcsh xonsh zsh)' \
+':shell:(bash elvish fish nushell posix powershell schemesh tcsh xonsh zsh)' \
 && ret=0
 ;;
 (query)

--- a/contrib/completions/zoxide.bash
+++ b/contrib/completions/zoxide.bash
@@ -275,7 +275,7 @@ _zoxide() {
             return 0
             ;;
         zoxide__subcmd__init)
-            opts="-h -V --no-cmd --cmd --hook --help --version bash elvish fish nushell posix powershell tcsh xonsh zsh"
+            opts="-h -V --no-cmd --cmd --hook --help --version bash elvish fish nushell posix powershell schemesh tcsh xonsh zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/contrib/completions/zoxide.nu
+++ b/contrib/completions/zoxide.nu
@@ -93,7 +93,7 @@ module completions {
   ]
 
   def "nu-complete zoxide init shell" [] {
-    [ "bash" "elvish" "fish" "nushell" "posix" "powershell" "tcsh" "xonsh" "zsh" ]
+    [ "bash" "elvish" "fish" "nushell" "posix" "powershell" "schemesh" "tcsh" "xonsh" "zsh" ]
   }
 
   def "nu-complete zoxide init hook" [] {

--- a/contrib/completions/zoxide.ts
+++ b/contrib/completions/zoxide.ts
@@ -288,6 +288,7 @@ const completion: Fig.Spec = {
           "nushell",
           "posix",
           "powershell",
+          "schemesh",
           "tcsh",
           "xonsh",
           "zsh",

--- a/src/cmd/cmd.rs
+++ b/src/cmd/cmd.rs
@@ -160,6 +160,7 @@ pub enum InitShell {
     #[clap(alias = "ksh")]
     Posix,
     Powershell,
+    Schemesh,
     Tcsh,
     Xonsh,
     Zsh,

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -6,7 +6,7 @@ use askama::Template;
 use crate::cmd::{Init, InitShell, Run};
 use crate::config;
 use crate::error::BrokenPipeHandler;
-use crate::shell::{Bash, Elvish, Fish, Nushell, Opts, Posix, Powershell, Tcsh, Xonsh, Zsh};
+use crate::shell::{Bash, Elvish, Fish, Nushell, Opts, Posix, Powershell, Schemesh, Tcsh, Xonsh, Zsh};
 
 impl Run for Init {
     fn run(&self) -> Result<()> {
@@ -22,6 +22,7 @@ impl Run for Init {
             InitShell::Nushell => Nushell(opts).render(),
             InitShell::Posix => Posix(opts).render(),
             InitShell::Powershell => Powershell(opts).render(),
+            InitShell::Schemesh => Schemesh(opts).render(),
             InitShell::Tcsh => Tcsh(opts).render(),
             InitShell::Xonsh => Xonsh(opts).render(),
             InitShell::Zsh => Zsh(opts).render(),

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -29,6 +29,7 @@ make_template!(Fish, "fish.txt");
 make_template!(Nushell, "nushell.txt");
 make_template!(Posix, "posix.txt");
 make_template!(Powershell, "powershell.txt");
+make_template!(Schemesh, "schemesh.txt");
 make_template!(Tcsh, "tcsh.txt");
 make_template!(Xonsh, "xonsh.txt");
 make_template!(Zsh, "zsh.txt");
@@ -243,6 +244,18 @@ mod tests {
 
         Command::new("pwsh")
             .args(["-NoLogo", "-NonInteractive", "-NoProfile", "-Command", &source])
+            .assert()
+            .success()
+            .stdout("")
+            .stderr("");
+    }
+
+    #[apply(opts)]
+    fn schemesh_schemesh(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+        let source = Schemesh(&opts).render().unwrap();
+        Command::new("schemesh")
+            .args(["--eval", &source])
             .assert()
             .success()
             .stdout("")

--- a/templates/schemesh.txt
+++ b/templates/schemesh.txt
@@ -1,0 +1,115 @@
+{%- let section = ";; =============================================================================\n;;" -%}
+{%- let not_configured = ";; -- not configured --" -%}
+
+{{ section }}
+;; Utility functions for zoxide.
+;;
+
+;; pwd based on the value of _ZO_RESOLVE_SYMLINKS.
+(define __zoxide_pwd
+  (lambda ()
+    (let ((pwd (charspan->string (sh-cwd (sh-globals)))))
+{%- if resolve_symlinks %}
+      (sh-run/string-rtrim-newlines {realpath (values pwd)})
+{%- else %}
+      pwd
+{%- endif %}
+    )))
+
+;; cd + custom logic based on the value of _ZO_ECHO.
+(define __zoxide_cd
+  (lambda args
+    (cond
+      ((null? args) (sh-cd (sh-globals)))
+      ((string=? (car args) "-") (sh-cd- (sh-globals)))
+      (else (sh-cd (sh-globals) (car args))))
+{%- if echo %}
+    (display (__zoxide_pwd))
+    (newline)
+{%- endif %}
+  ))
+
+{{ section }}
+;; Hook configuration for zoxide.
+;;
+
+{%- if hook != InitHook::None %}
+
+;; Hook to add new entries to the database.
+{%- if hook == InitHook::Prompt %}
+(define __zoxide_hook
+  (lambda (pwd-after-eval)
+    (sh-run {command zoxide add -- (values pwd-after-eval)})))
+{%- else if hook == InitHook::Pwd %}
+(define __zoxide_hook
+  (let ((pwd (__zoxide_pwd)))
+    (lambda (pwd-after-eval)
+      (unless (string=? pwd-after-eval pwd)
+        (set! pwd pwd-after-eval)
+        (sh-run {command zoxide add -- (values pwd-after-eval)})))))
+{%- endif %}
+
+;; Initialize hook.
+(let ((repl-original-eval (repl-current-eval)))
+  (repl-current-eval
+    (lambda (form env)
+      (let ((vals (repl-original-eval form env)))
+        (__zoxide_hook (__zoxide_pwd))
+        vals))))
+
+{%- endif %}
+
+{{ section }}
+;; When using zoxide with --no-cmd, alias these internal functions as desired.
+;;
+
+;; Jump to a directory using only keywords.
+(sh-alias "__zoxide_z"
+  (lambda (args)
+    (cond
+      ((null? args) (__zoxide_cd))
+      ((and (= (length args) 1)
+            (string=? (car args) "-"))
+       (__zoxide_cd (car args)))
+      ((and (= (length args) 1)
+            (file-directory? (car args)))
+       (__zoxide_cd (car args)))
+      ((and (= (length args) 2)
+            (string=? (car args) "--"))
+       (__zoxide_cd (cadr args)))
+      (else
+       (let* ((job {command zoxide query --exclude (__zoxide_pwd) -- (values args)})
+              (result (sh-run/string-rtrim-newlines job))
+              (status (sh-job-status job)))
+         (when (ok? status) (__zoxide_cd result)))))
+    (quote ())))
+
+;; Jump to a directory using interactive search.
+(sh-alias "__zoxide_zi"
+  (lambda (args)
+    (let* ((job {command zoxide query --interactive -- (values args)})
+           (result (sh-run/string-rtrim-newlines job))
+           (status (sh-job-status job)))
+      (when (ok? status) (__zoxide_cd result)))
+    (quote ())))
+
+{{ section }}
+;; Commands for zoxide. Disable these using --no-cmd.
+;;
+
+{%- match cmd %}
+{%- when Some with (cmd) %}
+
+(sh-alias "{{cmd}}" (quote ("__zoxide_z")))
+(sh-alias "{{cmd}}i" (quote ("__zoxide_zi")))
+
+{%- when None %}
+
+{{ not_configured }}
+
+{%- endmatch %}
+
+{{ section }}
+;; To initialize zoxide, add this to your configuration (usually ~/.config/schemesh/repl_init.ss):
+;;
+;; (sh-eval-string (sh-run/string {zoxide init schemesh}) 'scheme)


### PR DESCRIPTION
Schemesh is an interactive shell scriptable in Lisp (https://github.com/cosmos72/schemesh)

This PR adds the integration with schemesh.

Discussion: https://github.com/cosmos72/schemesh/issues/77

zoxide and Schemesh are both projects I really love, and I'd be very happy to see this PR merged.

After testing, all of the commands below produced the correct results. (also supports the _ZO_ECHO and _ZO_RESOLVE_SYMLINKS environment variables.)

```
zoxide init schemesh
zoxide init schemesh --cmd j
zoxide init schemesh --hook none/prompt/pwd
zoxide init schemesh --no-cmd
```

Currently, completion for the `__zoxide_z` command is not supported.

It also passes the `cargo test` suite.

```
> cargo test --features nix-dev schemesh_schemesh
running 24 tests
test shell::tests::schemesh_schemesh::cmd_1_None::hook_2_InitHook__Prompt::echo_1_false::resolve_symlinks_1_false ... ok
test shell::tests::schemesh_schemesh::cmd_1_None::hook_2_InitHook__Prompt::echo_1_false::resolve_symlinks_2_true ... ok
test shell::tests::schemesh_schemesh::cmd_1_None::hook_3_InitHook__Pwd::echo_2_true::resolve_symlinks_1_false ... ok
test shell::tests::schemesh_schemesh::cmd_1_None::hook_1_InitHook__None::echo_1_false::resolve_symlinks_1_false ... ok
test shell::tests::schemesh_schemesh::cmd_1_None::hook_2_InitHook__Prompt::echo_2_true::resolve_symlinks_2_true ... ok
test shell::tests::schemesh_schemesh::cmd_1_None::hook_3_InitHook__Pwd::echo_1_false::resolve_symlinks_1_false ... ok
test shell::tests::schemesh_schemesh::cmd_1_None::hook_3_InitHook__Pwd::echo_2_true::resolve_symlinks_2_true ... ok
test shell::tests::schemesh_schemesh::cmd_1_None::hook_2_InitHook__Prompt::echo_2_true::resolve_symlinks_1_false ... ok
test shell::tests::schemesh_schemesh::cmd_1_None::hook_1_InitHook__None::echo_2_true::resolve_symlinks_2_true ... ok
test shell::tests::schemesh_schemesh::cmd_1_None::hook_1_InitHook__None::echo_2_true::resolve_symlinks_1_false ... ok
test shell::tests::schemesh_schemesh::cmd_1_None::hook_3_InitHook__Pwd::echo_1_false::resolve_symlinks_2_true ... ok
test shell::tests::schemesh_schemesh::cmd_1_None::hook_1_InitHook__None::echo_1_false::resolve_symlinks_2_true ... ok
test shell::tests::schemesh_schemesh::cmd_2_Some___z___::hook_1_InitHook__None::echo_1_false::resolve_symlinks_1_false ... ok
test shell::tests::schemesh_schemesh::cmd_2_Some___z___::hook_1_InitHook__None::echo_2_true::resolve_symlinks_1_false ... ok
test shell::tests::schemesh_schemesh::cmd_2_Some___z___::hook_2_InitHook__Prompt::echo_1_false::resolve_symlinks_1_false ... ok
test shell::tests::schemesh_schemesh::cmd_2_Some___z___::hook_1_InitHook__None::echo_2_true::resolve_symlinks_2_true ... ok
test shell::tests::schemesh_schemesh::cmd_2_Some___z___::hook_2_InitHook__Prompt::echo_1_false::resolve_symlinks_2_true ... ok
test shell::tests::schemesh_schemesh::cmd_2_Some___z___::hook_2_InitHook__Prompt::echo_2_true::resolve_symlinks_1_false ... ok
test shell::tests::schemesh_schemesh::cmd_2_Some___z___::hook_3_InitHook__Pwd::echo_1_false::resolve_symlinks_1_false ... ok
test shell::tests::schemesh_schemesh::cmd_2_Some___z___::hook_2_InitHook__Prompt::echo_2_true::resolve_symlinks_2_true ... ok
test shell::tests::schemesh_schemesh::cmd_2_Some___z___::hook_3_InitHook__Pwd::echo_2_true::resolve_symlinks_1_false ... ok
test shell::tests::schemesh_schemesh::cmd_2_Some___z___::hook_3_InitHook__Pwd::echo_2_true::resolve_symlinks_2_true ... ok
test shell::tests::schemesh_schemesh::cmd_2_Some___z___::hook_3_InitHook__Pwd::echo_1_false::resolve_symlinks_2_true ... ok
test shell::tests::schemesh_schemesh::cmd_2_Some___z___::hook_1_InitHook__None::echo_1_false::resolve_symlinks_2_true ... ok

test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 496 filtered out; finished in 0.43s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
```