### PR TITLE
Fix minimum supported Nushell version in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `import` now takes a subcommand instead of the `--from` flag.
+- Nushell: upgrade minimum supported version to v0.106.0.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ zoxide can be installed in 4 easy steps:
    > ```
    >
    > **Note:**
-   > zoxide only supports Nushell v0.89.0+.
+   > zoxide only supports Nushell v0.106.0+.
 
    </details>
 

--- a/man/man1/zoxide-init.1
+++ b/man/man1/zoxide-init.1
@@ -45,7 +45,7 @@ Now, add this to the \fBend\fR of your config file (find it by running
     \fBsource ~/.zoxide.nu\fR
 .fi
 .sp
-Note: zoxide only supports Nushell v0.89.0+.
+Note: zoxide only supports Nushell v0.106.0+.
 .TP
 .B powershell
 Add this to the \fBend\fR of your config file (find it by running \fBecho

--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -104,4 +104,4 @@ export alias {{cmd}}i = __zoxide_zi
 #
 #   source ~/.zoxide.nu
 #
-# Note: zoxide only supports Nushell v0.89.0+.
+# Note: zoxide only supports Nushell v0.106.0+.


### PR DESCRIPTION
I am currently using Nushell version 0.90.1 on Windows (yes this is a very old version, I am in the process of migrating :D).

When updating zoxide to the latest version (0.10.0), the tool stops working with my old version of Nushell (`cd` results in `zoxide: no match found` for directories that are definitely in my history).

However, this project's README mentions zoxide supports Nushell v0.89.0+.

I performed a manual git bisect on Nushell and found only https://github.com/nushell/nushell/commit/f8b0af70ff3d6745e9284639a1b5899c382a564b and onwards works with the latest version of zoxide. This maps to Nushell version 0.106.0 and higher.

It looks to me like https://github.com/ajeetdsouza/zoxide/commit/ad5ea87783fded8c853bcc75c049ee46dfc54fb4 (implicitly) added this dependency by relying on the fixed expansion behavior of type `directory`.

I can confirm that zoxide 0.9.9 has no such issues with my old Nushell version.

Fix: Update the README to point to the true currently minimum supported Nushell version.