### PR TITLE
Fix zoxide edit list losing its score order after an edit

### DIFF
--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -24,8 +24,15 @@ impl Run for Edit {
                 }
                 db.save()?;
 
+                // Modifying an entry can leave the database unsorted: `remove` uses
+                // `swap_remove`, and `add` changes a rank in place. fzf displays
+                // entries in the order it receives them, so sort them here instead of
+                // relying on the order they happen to be stored in.
+                let mut dirs = db.dirs().iter().collect::<Vec<_>>();
+                dirs.sort_unstable_by(|dir1, dir2| dir2.score(now).total_cmp(&dir1.score(now)));
+
                 let stdout = &mut io::stdout().lock();
-                for dir in db.dirs().iter().rev() {
+                for dir in dirs {
                     write!(stdout, "{}\0", dir.display().with_score(now).with_separator('\t'))
                         .pipe_exit("fzf")?;
                 }

--- a/tests/edit.rs
+++ b/tests/edit.rs
@@ -1,0 +1,62 @@
+//! Test `zoxide edit` subcommands.
+
+use std::fs;
+
+use assert_cmd::Command;
+
+/// `zoxide edit <delete|increment|decrement>` prints the reload list for fzf.
+/// The list must be sorted by descending score, regardless of the order the
+/// entries happen to be stored in.
+#[test]
+fn edit_delete_output_is_sorted_by_score() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let dirs = tempfile::tempdir().unwrap();
+
+    // Add five directories with increasing scores.
+    let paths: Vec<String> = ["a", "b", "c", "d", "e"]
+        .iter()
+        .map(|name| {
+            let path = dirs.path().join(name);
+            fs::create_dir(&path).unwrap();
+            path.to_str().unwrap().to_string()
+        })
+        .collect();
+    for (idx, path) in paths.iter().enumerate() {
+        Command::cargo_bin("zoxide")
+            .unwrap()
+            .env("_ZO_DATA_DIR", data_dir.path())
+            .args(["add", "--score", &(idx + 1).to_string(), "--", path])
+            .assert()
+            .success();
+    }
+
+    // Deleting an entry must not disturb the ordering of the rest.
+    let output = Command::cargo_bin("zoxide")
+        .unwrap()
+        .env("_ZO_DATA_DIR", data_dir.path())
+        .args(["edit", "delete", "--", &paths[1]])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let output = String::from_utf8(output).unwrap();
+
+    let entries: Vec<(f64, &str)> = output
+        .split_terminator('\0')
+        .map(|line| {
+            let (score, path) = line.split_once('\t').unwrap();
+            (score.trim().parse::<f64>().unwrap(), path)
+        })
+        .collect();
+
+    let expected: Vec<&str> =
+        vec![&paths[4], &paths[3], &paths[2], &paths[0]].into_iter().map(String::as_str).collect();
+    let got: Vec<&str> = entries.iter().map(|(_, path)| *path).collect();
+    assert_eq!(expected, got);
+
+    assert!(
+        entries.windows(2).all(|w| w[0].0 >= w[1].0),
+        "scores are not in descending order: {entries:?}"
+    );
+}


### PR DESCRIPTION
## What's broken

In `zoxide edit`, pressing ctrl-d, ctrl-w or ctrl-s reshuffles the list under the cursor. After any edit the entries are no longer ordered by score.

## Repro

Add a few directories with different scores, run `zoxide edit`, then delete or increment one. The reload puts the highest-scoring entry somewhere in the middle:

```
$ zoxide edit delete -- /tmp/w/b   # (printed with \0 as newline)
  16.0	/tmp/w/d
  12.0	/tmp/w/c
  20.0	/tmp/w/e     <- highest score, third in the list
   4.0	/tmp/w/a
```

## The fix

`Database::remove` uses `swap_remove` and `add` mutates a rank in place, so neither leaves `dirs` sorted, and the reload branch iterated it directly. fzf runs with `--no-sort` here, so whatever order it receives is what the user sees. The reload path now sorts by descending score before printing.

Sorting a local `Vec` of references rather than calling the existing `db.sort_by_score` is deliberate: that helper marks the database dirty, and `save()` has already run at that point, so reusing it would either force a redundant write on every reload or leave a dirty flag unpersisted.

## Verification

```
$ zoxide edit delete -- /tmp/w/b
  20.0	/tmp/w/e
  16.0	/tmp/w/d
  12.0	/tmp/w/c
   4.0	/tmp/w/a
```

Test added in `tests/edit.rs`. `cargo test` passes (16 unit + 1 integration), fmt and clippy clean. `just test` needs nix, which I could not run, so I used plain cargo.

---
Disclosure: this patch was written with the help of Claude (an LLM). I reviewed the diff, ran the test suite, and verified the behaviour against a real build before opening this.
