### PR TITLE
POSIX: define `__zoxide_doctor` for all hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bash/Zsh: fix `z` failing on Cygwin/MSYS2 due to `cygpath` being passed a bad string.
 - Nushell: `z` now handles relative paths through symlinked directories.
+- POSIX: `z` and `zi` no longer report `__zoxide_doctor: not found` when initialized
+  with `--hook none` or `--hook pwd`.
 
 ## [0.10.0] - 2026-07-04
 

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -207,6 +207,21 @@ mod tests {
     }
 
     #[apply(opts)]
+    fn posix_dash_doctor(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+        let mut source = Posix(&opts).render().unwrap();
+        // `__zoxide_z` and `__zoxide_zi` call this on every invocation, so it
+        // must be defined for every hook.
+        source.push_str("\n__zoxide_doctor\n");
+
+        let assert =
+            Command::new("dash").args(["-e", "-u", "-c", &source]).assert().success().stderr("");
+        if opts.hook != InitHook::Pwd {
+            assert.stdout("");
+        }
+    }
+
+    #[apply(opts)]
     fn posix_shellcheck(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
         let opts = Opts { cmd, hook, echo, resolve_symlinks };
         let source = Posix(&opts).render().unwrap();

--- a/templates/posix.txt
+++ b/templates/posix.txt
@@ -56,6 +56,13 @@ if [ "${PS1:=}" = "${PS1#*\$(__zoxide_hook)}" ]; then
     PS1="${PS1}\$(__zoxide_hook)"
 fi
 
+{%- when InitHook::Pwd -%}
+\command printf "%s\n%s\n" \
+    "zoxide: PWD hooks are not supported on POSIX shells." \
+    "        Use 'zoxide init posix --hook prompt' instead."
+
+{%- endmatch %}
+
 # Report common issues.
 __zoxide_doctor() {
 {%- if hook != InitHook::Prompt %}
@@ -79,13 +86,6 @@ __zoxide_doctor() {
         '' >&2
 {%- endif %}
 }
-
-{%- when InitHook::Pwd -%}
-\command printf "%s\n%s\n" \
-    "zoxide: PWD hooks are not supported on POSIX shells." \
-    "        Use 'zoxide init posix --hook prompt' instead."
-
-{%- endmatch %}
 
 {{ section }}
 # When using zoxide with --no-cmd, alias these internal functions as desired.


### PR DESCRIPTION
`zoxide init posix` emits `__zoxide_doctor` only inside the `InitHook::Prompt` arm of the hook match, while `__zoxide_z` and `__zoxide_zi` call it unconditionally. With `--hook none` or `--hook pwd`, every jump writes to stderr:

```
$ eval "$(zoxide init posix --hook none)"; z foo
dash: 33: __zoxide_doctor: not found
```

The fix had to leave `--hook prompt` output untouched, since that is the configuration the README documents. Moving the definition below `{% endmatch %}` keeps it byte-identical there and supplies the no-op body for the other two hooks.

The body carries `{%- if hook != InitHook::Prompt %} return 0`, a branch unreachable while the definition sat inside the Prompt arm. `bash.txt` and `zsh.txt` define the function unconditionally with that same guard, so I matched them rather than deleting the two call sites, which would drop the check from POSIX shells.

`posix_dash_doctor` renders the template, appends a `__zoxide_doctor` call, then runs it under dash. Reverting `templates/posix.txt` fails 16 of its 24 cases, exactly the `None` and `Pwd` ones, exit 127. The 8 `Prompt` cases pass either way and are a pin. Existing `posix_dash` passes both ways, since sourcing never calls the function.

Limitation: the regression test covers dash, matching the existing `posix_dash` test. ksh checked by hand.
