### PR TITLE
docs: fix dead fzf man page link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ Environment variables[^2] can be used for configuration. They must be set before
 [felix]: https://github.com/kyoheiu/felix
 [freshports]: https://www.freshports.org/sysutils/zoxide/
 [fzf-installation]: https://github.com/junegunn/fzf#installation
-[fzf-man]: https://manpages.ubuntu.com/manpages/en/man1/fzf.1.html
+[fzf-man]: https://manpages.ubuntu.com/manpages/noble/en/man1/fzf.1.html
 [fzf]: https://github.com/junegunn/fzf
 [gentoo packages]: https://packages.gentoo.org/packages/app-shells/zoxide
 [glob]: https://man7.org/linux/man-pages/man7/glob.7.html


### PR DESCRIPTION
The fzf man page reference link in the README is dead:

- `https://manpages.ubuntu.com/manpages/en/man1/fzf.1.html` → **HTTP 404** (manpages.ubuntu.com requires a release segment in the path)

Replaced with the same page under the current LTS release:

- `https://manpages.ubuntu.com/manpages/noble/en/man1/fzf.1.html` → **HTTP 200** ("Ubuntu Manpage: fzf - a command-line fuzzy finder")
