### PR TITLE
fix: handle UNC paths in resolve_path on Windows

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -332,6 +332,14 @@ pub fn resolve_path(path: impl AsRef<Path>) -> Result<PathBuf> {
                     base_path = get_drive_path(drive_letter);
                     stack.extend(base_path.components());
                 }
+                Prefix::UNC(..) | Prefix::VerbatimUNC(..) => {
+                    let prefix_component = components.next().unwrap();
+                    stack.push(prefix_component);
+                    if components.peek() == Some(&Component::RootDir) {
+                        let root = components.next().unwrap();
+                        stack.push(root);
+                    }
+                }
                 _ => bail!("invalid path: {}", path.display()),
             },
             Some(Component::RootDir) => {


### PR DESCRIPTION
## Problem

When using zoxide in MSYS2 (or similar Unix-like environments) on Windows, navigating to a network drive via a path like `//a.network-drive/a-folder` produces:

```
zoxide: could not get drive letter: \\a.network-drive\a-folder
```

The `//` prefix is normalized by Rust to `\\` (UNC path), which has a `Prefix::UNC` component. `resolve_path` only handled `Disk` and `VerbatimDisk` prefixes and bailed on everything else, hitting the error path that tries to extract a drive letter from the current directory.

## Fix

Add handling for `Prefix::UNC` and `Prefix::VerbatimUNC` in the `resolve_path` match. UNC paths already carry their server and share in the prefix component, so we push the prefix and root directly — no drive letter resolution needed.

Fixes #331
