### PR TITLE
docs: add superfile to third-party integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,30 +438,31 @@ Environment variables[^2] can be used for configuration. They must be set before
 
 ## Third-party integrations
 
-| Application           | Description                                  | Plugin                     |
-| --------------------- | -------------------------------------------- | -------------------------- |
-| [aerc]                | Email client                                 | Natively supported         |
-| [alfred]              | macOS launcher                               | [alfred-zoxide]            |
-| [clink]               | Improved cmd.exe for Windows                 | [clink-zoxide]             |
-| [emacs]               | Text editor                                  | [zoxide.el]                |
-| [felix]               | File manager                                 | Natively supported         |
-| [joshuto]             | File manager                                 | Natively supported         |
-| [lf]                  | File manager                                 | See the [wiki][lf-wiki]    |
-| [nnn]                 | File manager                                 | [nnn-autojump]             |
-| [ranger]              | File manager                                 | [ranger-zoxide]            |
-| [raycast]             | macOS launcher                               | [raycast-zoxide]           |
-| [rfm]                 | File manager                                 | Natively supported         |
-| [sesh]                | `tmux` session manager                       | Natively supported         |
-| [telescope.nvim]      | Fuzzy finder for Neovim                      | [telescope-zoxide]         |
-| [tmux-session-wizard] | `tmux` session manager                       | Natively supported         |
-| [tmux-sessionx]       | `tmux` session manager                       | Natively supported         |
-| [vim] / [neovim]      | Text editor                                  | [zoxide.vim]               |
-| [xplr]                | File manager                                 | [zoxide.xplr]              |
-| [xxh]                 | Transports shell configuration over SSH      | [xxh-plugin-prerun-zoxide] |
-| [yazi]                | File manager                                 | Natively supported         |
-| [zabb]                | Finds the shortest possible query for a path | Natively supported         |
-| [zesh]                | `zellij` session manager                     | Natively supported         |
-| [zsh-autocomplete]    | Realtime completions for zsh                 | Natively supported         |
+| Application           | Description                                  | Plugin                                  |
+| --------------------- | -------------------------------------------- | --------------------------------------- |
+| [aerc]                | Email client                                 | Natively supported                      |
+| [alfred]              | macOS launcher                               | [alfred-zoxide]                         |
+| [clink]               | Improved cmd.exe for Windows                 | [clink-zoxide]                          |
+| [emacs]               | Text editor                                  | [zoxide.el]                             |
+| [felix]               | File manager                                 | Natively supported                      |
+| [joshuto]             | File manager                                 | Natively supported                      |
+| [lf]                  | File manager                                 | See the [wiki][lf-wiki]                 |
+| [nnn]                 | File manager                                 | [nnn-autojump]                          |
+| [ranger]              | File manager                                 | [ranger-zoxide]                         |
+| [raycast]             | macOS launcher                               | [raycast-zoxide]                        |
+| [rfm]                 | File manager                                 | Natively supported                      |
+| [sesh]                | `tmux` session manager                       | Natively supported                      |
+| [superfile]           | File manager                                 | [Natively supported][superfile-plugins] |
+| [telescope.nvim]      | Fuzzy finder for Neovim                      | [telescope-zoxide]                      |
+| [tmux-session-wizard] | `tmux` session manager                       | Natively supported                      |
+| [tmux-sessionx]       | `tmux` session manager                       | Natively supported                      |
+| [vim] / [neovim]      | Text editor                                  | [zoxide.vim]                            |
+| [xplr]                | File manager                                 | [zoxide.xplr]                           |
+| [xxh]                 | Transports shell configuration over SSH      | [xxh-plugin-prerun-zoxide]              |
+| [yazi]                | File manager                                 | Natively supported                      |
+| [zabb]                | Finds the shortest possible query for a path | Natively supported                      |
+| [zesh]                | `zellij` session manager                     | Natively supported                      |
+| [zsh-autocomplete]    | Realtime completions for zsh                 | Natively supported                      |
 
 [^1]:
     Debian / Ubuntu derivatives update their packages very slowly. If you're
@@ -527,6 +528,8 @@ Environment variables[^2] can be used for configuration. They must be set before
 [slackbuilds]: https://slackbuilds.org/repository/15.0/system/zoxide/
 [slackbuilds-howto]: https://slackbuilds.org/howto/
 [solus packages]: https://github.com/getsolus/packages/tree/main/packages/z/zoxide/
+[superfile]: https://github.com/yorukot/superfile
+[superfile-plugins]: https://superfile.dev/list/plugin-list/
 [telescope-zoxide]: https://github.com/jvgrootveld/telescope-zoxide
 [telescope.nvim]: https://github.com/nvim-telescope/telescope.nvim
 [termux]: https://github.com/termux/termux-packages/tree/master/packages/zoxide


### PR DESCRIPTION
superfile has built-in zoxide navigation, enabled by setting
zoxide_support = true in config.toml and bound to `z`, so link to its
plugin docs for setup instructions.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Bc7NmSBVezDZfNDr2VFqnv