### PR TITLE
Add --db-only to shell initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,10 @@ When calling `zoxide init`, the following flags are available:
   - Changes the prefix of the `z` and `zi` commands.
   - `--cmd j` would change the commands to (`j`, `ji`).
   - `--cmd cd` would replace the `cd` command.
+- `--db-only`
+  - Searches only the database instead of trying existing directories first.
+  - No-argument navigation, shell history shortcuts, and explicit `z -- path`
+    navigation (where supported) are unchanged.
 - `--hook <HOOK>`
   - Changes how often zoxide increments a directory's score:
 

--- a/contrib/completions/_zoxide
+++ b/contrib/completions/_zoxide
@@ -174,6 +174,7 @@ _arguments "${_arguments_options[@]}" : \
 '--cmd=[Changes the prefix of the \`z\` and \`zi\` commands]:CMD:_default' \
 '--hook=[Changes how often zoxide increments a directory'\''s score]:HOOK:(none prompt pwd)' \
 '--no-cmd[Prevents zoxide from defining the \`z\` and \`zi\` commands]' \
+'--db-only[Searches only the database instead of trying existing directories first]' \
 '-h[Print help]' \
 '--help[Print help]' \
 '-V[Print version]' \

--- a/contrib/completions/_zoxide.ps1
+++ b/contrib/completions/_zoxide.ps1
@@ -147,6 +147,7 @@ Register-ArgumentCompleter -Native -CommandName 'zoxide' -ScriptBlock {
             [CompletionResult]::new('--cmd', '--cmd', [CompletionResultType]::ParameterName, 'Changes the prefix of the `z` and `zi` commands')
             [CompletionResult]::new('--hook', '--hook', [CompletionResultType]::ParameterName, 'Changes how often zoxide increments a directory''s score')
             [CompletionResult]::new('--no-cmd', '--no-cmd', [CompletionResultType]::ParameterName, 'Prevents zoxide from defining the `z` and `zi` commands')
+            [CompletionResult]::new('--db-only', '--db-only', [CompletionResultType]::ParameterName, 'Searches only the database instead of trying existing directories first')
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
             [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
             [CompletionResult]::new('-V', '-V ', [CompletionResultType]::ParameterName, 'Print version')

--- a/contrib/completions/zoxide.bash
+++ b/contrib/completions/zoxide.bash
@@ -275,7 +275,7 @@ _zoxide() {
             return 0
             ;;
         zoxide__subcmd__init)
-            opts="-h -V --no-cmd --cmd --hook --help --version bash elvish fish nushell posix powershell tcsh xonsh zsh"
+            opts="-h -V --no-cmd --cmd --db-only --hook --help --version bash elvish fish nushell posix powershell tcsh xonsh zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/contrib/completions/zoxide.elv
+++ b/contrib/completions/zoxide.elv
@@ -130,6 +130,7 @@ set edit:completion:arg-completer[zoxide] = {|@words|
             cand --cmd 'Changes the prefix of the `z` and `zi` commands'
             cand --hook 'Changes how often zoxide increments a directory''s score'
             cand --no-cmd 'Prevents zoxide from defining the `z` and `zi` commands'
+            cand --db-only 'Searches only the database instead of trying existing directories first'
             cand -h 'Print help'
             cand --help 'Print help'
             cand -V 'Print version'

--- a/contrib/completions/zoxide.fish
+++ b/contrib/completions/zoxide.fish
@@ -81,6 +81,7 @@ complete -c zoxide -n "__fish_zoxide_using_subcommand init" -l hook -d 'Changes 
 prompt\t''
 pwd\t''"
 complete -c zoxide -n "__fish_zoxide_using_subcommand init" -l no-cmd -d 'Prevents zoxide from defining the `z` and `zi` commands'
+complete -c zoxide -n "__fish_zoxide_using_subcommand init" -l db-only -d 'Searches only the database instead of trying existing directories first'
 complete -c zoxide -n "__fish_zoxide_using_subcommand init" -s h -l help -d 'Print help'
 complete -c zoxide -n "__fish_zoxide_using_subcommand init" -s V -l version -d 'Print version'
 complete -c zoxide -n "__fish_zoxide_using_subcommand query" -l exclude -d 'Exclude the current directory' -r -f -a "(__fish_complete_directories)"

--- a/contrib/completions/zoxide.nu
+++ b/contrib/completions/zoxide.nu
@@ -104,6 +104,7 @@ module completions {
   export extern "zoxide init" [
     --no-cmd                  # Prevents zoxide from defining the `z` and `zi` commands
     --cmd: string             # Changes the prefix of the `z` and `zi` commands
+    --db-only                 # Searches only the database instead of trying existing directories first
     --hook: string@"nu-complete zoxide init hook" # Changes how often zoxide increments a directory's score
     --help(-h)                # Print help
     --version(-V)             # Print version

--- a/contrib/completions/zoxide.ts
+++ b/contrib/completions/zoxide.ts
@@ -271,6 +271,10 @@ const completion: Fig.Spec = {
           description: "Prevents zoxide from defining the `z` and `zi` commands",
         },
         {
+          name: "--db-only",
+          description: "Searches only the database instead of trying existing directories first",
+        },
+        {
           name: ["-h", "--help"],
           description: "Print help",
         },

--- a/man/man1/zoxide-init.1
+++ b/man/man1/zoxide-init.1
@@ -94,6 +94,11 @@ Changes the prefix of the \fBz\fR and \fBzi\fR commands.
 \fB--cmd cd\fR would replace the \fBcd\fR command (doesn't work on Nushell /
 POSIX shells).
 .TP
+.B --db-only
+Searches only the database instead of trying existing directories first.
+No-argument navigation, shell history shortcuts, and explicit \fBz -- path\fR
+navigation (where supported) are unchanged.
+.TP
 .B -h, --help
 Print help information.
 .TP

--- a/src/cmd/cmd.rs
+++ b/src/cmd/cmd.rs
@@ -139,6 +139,10 @@ pub struct Init {
     #[clap(long, default_value = "z")]
     pub cmd: String,
 
+    /// Searches only the database instead of trying existing directories first
+    #[clap(long)]
+    pub db_only: bool,
+
     /// Changes how often zoxide increments a directory's score
     #[clap(value_enum, long, default_value = "pwd")]
     pub hook: InitHook,

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -13,7 +13,7 @@ impl Run for Init {
         let cmd = if self.no_cmd { None } else { Some(self.cmd.as_str()) };
         let echo = config::echo();
         let resolve_symlinks = config::resolve_symlinks();
-        let opts = &Opts { cmd, hook: self.hook, echo, resolve_symlinks };
+        let opts = &Opts { cmd, hook: self.hook, echo, resolve_symlinks, db_only: self.db_only };
 
         let source = match self.shell {
             InitShell::Bash => Bash(opts).render(),

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -6,6 +6,7 @@ pub struct Opts<'a> {
     pub hook: InitHook,
     pub echo: bool,
     pub resolve_symlinks: bool,
+    pub db_only: bool,
 }
 
 macro_rules! make_template {
@@ -50,12 +51,19 @@ mod tests {
         #[values(InitHook::None, InitHook::Prompt, InitHook::Pwd)] hook: InitHook,
         #[values(false, true)] echo: bool,
         #[values(false, true)] resolve_symlinks: bool,
+        #[values(false, true)] db_only: bool,
     ) {
     }
 
     #[apply(opts)]
-    fn bash_bash(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
-        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+    fn bash_bash(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+        db_only: bool,
+    ) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks, db_only };
         let source = Bash(&opts).render().unwrap();
         Command::new("bash")
             .args(["--noprofile", "--norc", "-e", "-u", "-o", "pipefail", "-c", &source])
@@ -66,8 +74,14 @@ mod tests {
     }
 
     #[apply(opts)]
-    fn bash_shellcheck(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
-        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+    fn bash_shellcheck(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+        db_only: bool,
+    ) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks, db_only };
         let source = Bash(&opts).render().unwrap();
 
         Command::new("shellcheck")
@@ -80,8 +94,14 @@ mod tests {
     }
 
     #[apply(opts)]
-    fn bash_shfmt(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
-        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+    fn bash_shfmt(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+        db_only: bool,
+    ) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks, db_only };
         let mut source = Bash(&opts).render().unwrap();
         source.push('\n');
 
@@ -95,8 +115,14 @@ mod tests {
     }
 
     #[apply(opts)]
-    fn elvish_elvish(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
-        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+    fn elvish_elvish(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+        db_only: bool,
+    ) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks, db_only };
         let mut source = String::new();
 
         // Filter out lines using edit:*, since those functions are only available in
@@ -115,8 +141,14 @@ mod tests {
     }
 
     #[apply(opts)]
-    fn fish_no_builtin_abbr(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
-        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+    fn fish_no_builtin_abbr(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+        db_only: bool,
+    ) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks, db_only };
         let source = Fish(&opts).render().unwrap();
         assert!(
             !source.contains("builtin abbr"),
@@ -125,8 +157,14 @@ mod tests {
     }
 
     #[apply(opts)]
-    fn fish_fish(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
-        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+    fn fish_fish(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+        db_only: bool,
+    ) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks, db_only };
         let source = Fish(&opts).render().unwrap();
 
         let tempdir = tempfile::tempdir().unwrap();
@@ -142,8 +180,14 @@ mod tests {
     }
 
     #[apply(opts)]
-    fn fish_fishindent(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
-        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+    fn fish_fishindent(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+        db_only: bool,
+    ) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks, db_only };
         let mut source = Fish(&opts).render().unwrap();
         source.push('\n');
 
@@ -160,8 +204,14 @@ mod tests {
     }
 
     #[apply(opts)]
-    fn nushell_nushell(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
-        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+    fn nushell_nushell(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+        db_only: bool,
+    ) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks, db_only };
         let source = Nushell(&opts).render().unwrap();
 
         let tempdir = tempfile::tempdir().unwrap();
@@ -180,8 +230,14 @@ mod tests {
     }
 
     #[apply(opts)]
-    fn posix_bash(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
-        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+    fn posix_bash(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+        db_only: bool,
+    ) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks, db_only };
         let source = Posix(&opts).render().unwrap();
 
         let assert = Command::new("bash")
@@ -195,8 +251,14 @@ mod tests {
     }
 
     #[apply(opts)]
-    fn posix_dash(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
-        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+    fn posix_dash(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+        db_only: bool,
+    ) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks, db_only };
         let source = Posix(&opts).render().unwrap();
 
         let assert =
@@ -207,8 +269,14 @@ mod tests {
     }
 
     #[apply(opts)]
-    fn posix_shellcheck(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
-        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+    fn posix_shellcheck(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+        db_only: bool,
+    ) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks, db_only };
         let source = Posix(&opts).render().unwrap();
 
         Command::new("shellcheck")
@@ -221,8 +289,14 @@ mod tests {
     }
 
     #[apply(opts)]
-    fn posix_shfmt(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
-        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+    fn posix_shfmt(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+        db_only: bool,
+    ) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks, db_only };
         let mut source = Posix(&opts).render().unwrap();
         source.push('\n');
 
@@ -236,8 +310,14 @@ mod tests {
     }
 
     #[apply(opts)]
-    fn powershell_pwsh(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
-        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+    fn powershell_pwsh(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+        db_only: bool,
+    ) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks, db_only };
         let mut source = "Set-StrictMode -Version latest\n".to_string();
         Powershell(&opts).render_into(&mut source).unwrap();
 
@@ -250,8 +330,14 @@ mod tests {
     }
 
     #[apply(opts)]
-    fn tcsh_tcsh(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
-        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+    fn tcsh_tcsh(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+        db_only: bool,
+    ) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks, db_only };
         let source = Tcsh(&opts).render().unwrap();
 
         Command::new("tcsh")
@@ -264,8 +350,14 @@ mod tests {
     }
 
     #[apply(opts)]
-    fn xonsh_black(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
-        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+    fn xonsh_black(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+        db_only: bool,
+    ) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks, db_only };
         let mut source = Xonsh(&opts).render().unwrap();
         source.push('\n');
 
@@ -278,16 +370,28 @@ mod tests {
     }
 
     #[apply(opts)]
-    fn xonsh_mypy(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
-        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+    fn xonsh_mypy(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+        db_only: bool,
+    ) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks, db_only };
         let source = Xonsh(&opts).render().unwrap();
 
         Command::new("mypy").args(["--command", &source, "--strict"]).assert().success().stderr("");
     }
 
     #[apply(opts)]
-    fn xonsh_pylint(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
-        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+    fn xonsh_pylint(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+        db_only: bool,
+    ) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks, db_only };
         let mut source = Xonsh(&opts).render().unwrap();
         source.push('\n');
 
@@ -300,8 +404,14 @@ mod tests {
     }
 
     #[apply(opts)]
-    fn xonsh_xonsh(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
-        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+    fn xonsh_xonsh(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+        db_only: bool,
+    ) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks, db_only };
         let source = Xonsh(&opts).render().unwrap();
 
         let tempdir = tempfile::tempdir().unwrap();
@@ -317,8 +427,14 @@ mod tests {
     }
 
     #[apply(opts)]
-    fn zsh_shellcheck(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
-        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+    fn zsh_shellcheck(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+        db_only: bool,
+    ) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks, db_only };
         let source = Zsh(&opts).render().unwrap();
 
         // ShellCheck doesn't support zsh yet: https://github.com/koalaman/shellcheck/issues/809
@@ -332,8 +448,14 @@ mod tests {
     }
 
     #[apply(opts)]
-    fn zsh_zsh(cmd: Option<&str>, hook: InitHook, echo: bool, resolve_symlinks: bool) {
-        let opts = Opts { cmd, hook, echo, resolve_symlinks };
+    fn zsh_zsh(
+        cmd: Option<&str>,
+        hook: InitHook,
+        echo: bool,
+        resolve_symlinks: bool,
+        db_only: bool,
+    ) {
+        let opts = Opts { cmd, hook, echo, resolve_symlinks, db_only };
         let source = Zsh(&opts).render().unwrap();
 
         Command::new("zsh")

--- a/templates/bash.txt
+++ b/templates/bash.txt
@@ -115,8 +115,10 @@ function __zoxide_z() {
         __zoxide_cd ~
     elif [[ $# -eq 1 && $1 == '-' ]]; then
         __zoxide_cd "${OLDPWD}"
+{%- if !db_only %}
     elif [[ $# -eq 1 ]] && (\builtin cd -- "$1") &>/dev/null; then
         __zoxide_cd "$1"
+{%- endif %}
     elif [[ $# -eq 2 && $1 == '--' ]]; then
         __zoxide_cd "$2"
     elif [[ ${@: -1} == "${__zoxide_z_prefix}"?* ]]; then

--- a/templates/elvish.txt
+++ b/templates/elvish.txt
@@ -50,8 +50,10 @@ fn __zoxide_z {|@rest|
         __zoxide_cd ~
     } elif (builtin:eq [-] $rest) {
         __zoxide_cd $oldpwd
+{%- if !db_only %}
     } elif (and ('builtin:==' (builtin:count $rest) 1) (path:is-dir &follow-symlink=$true $rest[0])) {
         __zoxide_cd $rest[0]
+{%- endif %}
     } else {
         var path
         try {

--- a/templates/fish.txt
+++ b/templates/fish.txt
@@ -79,8 +79,10 @@ function __zoxide_z
         __zoxide_cd $HOME
     else if test "$argv" = -
         __zoxide_cd -
+{%- if !db_only %}
     else if test $argc -eq 1 -a -d $argv[1]
         __zoxide_cd $argv[1]
+{%- endif %}
     else if test $argc -eq 2 -a $argv[1] = --
         __zoxide_cd -- $argv[2]
     else

--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -60,7 +60,9 @@ export def --env --wrapped __zoxide_z [...rest: directory] {
   match $rest {
     [] => { cd ~ },
     [ '-' ] => { cd - },
+{%- if !db_only %}
     [ $arg ] if (try { cd $arg; true } catch { false }) => {},
+{%- endif %}
     _ => {
       cd (^zoxide query --exclude $env.PWD -- ...$rest | str trim -r -c "\n")
     }

--- a/templates/posix.txt
+++ b/templates/posix.txt
@@ -105,8 +105,10 @@ __zoxide_z() {
             \command printf 'zoxide: $OLDPWD is not set'
             return 1
         fi
+{%- if !db_only %}
     elif [ "$#" -eq 1 ] && (\command cd -- "$1") >/dev/null 2>&1; then
         __zoxide_cd "$1"
+{%- endif %}
     else
         __zoxide_result="$(\command zoxide query --exclude "$(__zoxide_pwd || \command true)" -- "$@")" &&
             __zoxide_cd "${__zoxide_result}"

--- a/templates/powershell.txt
+++ b/templates/powershell.txt
@@ -110,12 +110,14 @@ function global:__zoxide_z {
     elseif ($args.Length -eq 1 -and ($args[0] -eq '-' -or $args[0] -eq '+')) {
         __zoxide_cd $args[0] $false
     }
+{%- if !db_only %}
     elseif ($args.Length -eq 1 -and (Microsoft.PowerShell.Management\Test-Path -PathType Container -LiteralPath $args[0])) {
         __zoxide_cd $args[0] $true
     }
     elseif ($args.Length -eq 1 -and (Microsoft.PowerShell.Management\Test-Path -PathType Container -Path $args[0] )) {
         __zoxide_cd $args[0] $false
     }
+{%- endif %}
     else {
         $result = __zoxide_pwd
         if ($null -ne $result) {

--- a/templates/tcsh.txt
+++ b/templates/tcsh.txt
@@ -46,8 +46,10 @@ if ("$#__zoxide_args" == 0) then\
 else\
     if ("$#__zoxide_args" == 1 && "$__zoxide_args[1]" == "-") then\
         cd -\
+{%- if !db_only %}
     else if ("$#__zoxide_args" == 1 && -d "$__zoxide_args[1]") then\
         cd "$__zoxide_args[1]"\
+{%- endif %}
     else\
         set __zoxide_pwd = `{{ pwd_cmd }}`\
         set __zoxide_result = "`zoxide query --exclude '"'"'$__zoxide_pwd'"'"' -- $__zoxide_args`" && cd "$__zoxide_result"\

--- a/templates/xonsh.txt
+++ b/templates/xonsh.txt
@@ -4,8 +4,12 @@
 # pylint: disable=missing-module-docstring
 
 import builtins  # pylint: disable=unused-import
+{%- if !db_only || resolve_symlinks %}
 import os
+{%- if !db_only %}
 import os.path
+{%- endif %}
+{%- endif %}
 import subprocess
 import sys
 import typing
@@ -119,8 +123,10 @@ def __zoxide_z(args: list[str]) -> None:
         __zoxide_cd()
     elif args == ["-"]:
         __zoxide_cd("-")
+{%- if !db_only %}
     elif len(args) == 1 and os.path.isdir(args[0]):
         __zoxide_cd(args[0])
+{%- endif %}
     else:
         try:
             zoxide = __zoxide_bin()

--- a/templates/zsh.txt
+++ b/templates/zsh.txt
@@ -91,7 +91,11 @@ function __zoxide_z() {
         __zoxide_cd ~
     elif [[ "$#" -eq 1 ]] && [[ "$1" = '-' ]]; then
         __zoxide_cd "${OLDPWD}"
+{%- if db_only %}
+    elif [[ "$#" -eq 1 ]] && [[ "$1" =~ ^[-+][0-9]+$ ]]; then
+{%- else %}
     elif [[ "$#" -eq 1 ]] && { [[ "$1" =~ ^[-+][0-9]+$ ]] || (\builtin cd -q -- "$1") &>/dev/null; }; then
+{%- endif %}
         __zoxide_cd "$1"
     elif [[ "$#" -eq 2 ]] && [[ "$1" = "--" ]]; then
         __zoxide_cd "$2"

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -1,0 +1,124 @@
+use assert_cmd::Command;
+use rstest::rstest;
+
+#[rstest]
+fn init_db_only(
+    #[values("bash", "elvish", "fish", "nushell", "posix", "powershell", "tcsh", "xonsh", "zsh")]
+    shell: &str,
+    #[values(false, true)] db_only: bool,
+    #[values(false, true)] no_cmd: bool,
+) {
+    let mut command = Command::cargo_bin("zoxide").unwrap();
+    command.args(["init", shell]);
+    if db_only {
+        command.arg("--db-only");
+    }
+    if no_cmd {
+        command.arg("--no-cmd");
+    }
+    command.assert().success().stderr("");
+}
+
+#[cfg(feature = "nix-dev")]
+fn navigation(shell: &str, db_only: bool, script: &str, args: &[&str]) {
+    let temp = tempfile::tempdir().unwrap();
+    let root = dunce::canonicalize(temp.path()).unwrap();
+    let local = root.join("local");
+    let database = root.join("database");
+    std::fs::create_dir_all(local.join("match space")).unwrap();
+    std::fs::create_dir_all(database.join("match space")).unwrap();
+    std::fs::create_dir_all(local.join("untracked")).unwrap();
+    let data = root.join("data");
+    Command::cargo_bin("zoxide")
+        .unwrap()
+        .env("_ZO_DATA_DIR", &data)
+        .env_remove("_ZO_EXCLUDE_DIRS")
+        .env_remove("_ZO_MAXAGE")
+        .args(["add", "--"])
+        .arg(database.join("match space"))
+        .assert()
+        .success();
+    let mut init = Command::cargo_bin("zoxide").unwrap();
+    init.args(["init", shell, "--hook", if shell == "posix" { "prompt" } else { "none" }]);
+    if db_only {
+        init.arg("--db-only");
+    }
+    let output = init.env_remove("_ZO_ECHO").env_remove("_ZO_RESOLVE_SYMLINKS").output().unwrap();
+    assert!(output.status.success());
+    let source = String::from_utf8(output.stdout).unwrap() + script;
+    let bin = assert_cmd::cargo::cargo_bin("zoxide");
+    let path = std::env::join_paths(
+        std::iter::once(bin.parent().unwrap().to_path_buf())
+            .chain(std::env::split_paths(&std::env::var_os("PATH").unwrap())),
+    )
+    .unwrap();
+    Command::new(if shell == "powershell" { "pwsh" } else { "bash" })
+        .args(args)
+        .arg(source)
+        .current_dir(&local)
+        .env("PATH", path)
+        .env("_ZO_DATA_DIR", data)
+        .env_remove("_ZO_EXCLUDE_DIRS")
+        .env_remove("_ZO_MAXAGE")
+        .env_remove("_ZO_RESOLVE_SYMLINKS")
+        .env("EXPECTED", if db_only { database } else { local.clone() }.join("match space"))
+        .env("START", &local)
+        .env("DB_ONLY", if db_only { "1" } else { "0" })
+        .assert()
+        .success()
+        .stderr("");
+}
+
+#[cfg(feature = "nix-dev")]
+#[rstest]
+fn powershell_db_only_navigation(#[values(false, true)] db_only: bool) {
+    navigation(
+        "powershell",
+        db_only,
+        r#"
+$ErrorActionPreference = 'Stop'
+z 'match space'
+if ((Get-Location).Path -ne $env:EXPECTED) { throw 'wrong destination' }
+z -
+if ((Get-Location).Path -ne $env:START) { throw 'history shortcut failed' }
+z 'untracked' 2>$null
+if ($env:DB_ONLY -eq '1') {
+    if ($LASTEXITCODE -eq 0) { throw 'untracked directory accepted' }
+    if ((Get-Location).Path -ne $env:START) { throw 'untracked directory visited' }
+} else {
+    if ((Get-Location).Path -ne (Join-Path $env:START 'untracked')) { throw 'direct navigation failed' }
+    z -
+}
+z 'not-in-database' 2>$null
+if ($LASTEXITCODE -eq 0) { throw 'missing query succeeded' }
+if ((Get-Location).Path -ne $env:START) { throw 'failed query changed directory' }
+z
+if ((Get-Location).Path -ne $HOME) { throw 'home navigation failed' }
+"#,
+        &["-NoLogo", "-NonInteractive", "-NoProfile", "-Command"],
+    );
+}
+
+#[cfg(feature = "nix-dev")]
+#[rstest]
+fn bash_db_only_navigation(
+    #[values("bash", "posix")] shell: &str,
+    #[values(false, true)] db_only: bool,
+) {
+    navigation(
+        shell,
+        db_only,
+        r#"
+z 'match space'
+if command -v cygpath >/dev/null; then EXPECTED=$(cygpath -u "$EXPECTED"); START=$(cygpath -u "$START"); fi
+[ "$PWD" = "$EXPECTED" ] || exit 10
+z -
+[ "$PWD" = "$START" ] || exit 11
+if z 'not-in-database' 2>/dev/null; then exit 12; fi
+[ "$PWD" = "$START" ] || exit 13
+z
+[ "$PWD" = "$HOME" ] || exit 14
+"#,
+        &["--noprofile", "--norc", "-e", "-u", "-c"],
+    );
+}


### PR DESCRIPTION
# Add --db-only to shell initialization

## Summary

Add `zoxide init <shell> --db-only` to query the database instead of trying an existing directory first. This applies to all nine supported shells and preserves default behavior, no-argument navigation, history shortcuts, and explicit `z -- path` navigation where supported.

Update CLI help, README, manual, and generated completions. Add navigation regressions for competing local/database directories and expand the shell validation matrix to cover both modes.

Fixes #1297

## Testing

- `cargo test --locked --no-fail-fast --workspace`: 52 passed.
- `cargo test --locked --all-features --bin zoxide powershell_pwsh`: 48 passed.
- `cargo test --locked --all-features --test init powershell_db_only_navigation`: 2 passed, including with an inherited `_ZO_EXCLUDE_DIRS=*` to verify isolation.
- `cargo clippy --locked --all-features --all-targets -- -Dwarnings`: passed.
- `cargo test --locked --all-features --test init bash_db_only_navigation`: 4 passed using portable Git Bash.
- Bash initialization, POSIX initialization in Bash, and POSIX initialization in Dash: 48 cases each passed.
- Bash shfmt validation: 48 passed.
- `cargo +nightly-2026-05-10 fmt --all --check`: passed. This is the latest nightly in the repository's pinned rust-overlay.
- `git diff --check`: passed.

Windows ShellCheck reports SC2312 in the unchanged cygpath helpers, and POSIX shfmt reports existing indentation in that Windows-only helper. Current nightly (2026-09-05) reports the same comment wrapping changes on both the untouched baseline and this branch; the pinned nightly passes. GNU linking emitted non-fatal `.drectve` warnings.
